### PR TITLE
explicit initialization of member variables

### DIFF
--- a/grid_map_core/include/grid_map_core/iterators/LineIterator.hpp
+++ b/grid_map_core/include/grid_map_core/iterators/LineIterator.hpp
@@ -108,10 +108,10 @@ private:
   Index end_;
 
   //! Current cell number.
-  unsigned int iCell_;
+  unsigned int iCell_ = 0;
 
   //! Number of cells in the line.
-  unsigned int nCells_;
+  unsigned int nCells_ = 0;
 
   //! Helper variables for Bresenham Line Drawing algorithm.
   Size increment1_, increment2_;


### PR DESCRIPTION
in some case, default initialization does not work somehow and isPastEnd() returns false. the iterator returns a far away index.