### PR TITLE
correct the error of extendToInclude function

### DIFF
--- a/grid_map_core/src/GridMap.cpp
+++ b/grid_map_core/src/GridMap.cpp
@@ -494,7 +494,7 @@ bool GridMap::extendToInclude(const GridMap& other)
       position_.x() += resolution_ - shift.x();
     }
     if (size_.x() % 2 != mapCopy.getSize().x() % 2) {
-      position_.x() += -std::copysign(resolution_ / 2.0, shift.x());
+      position_.x() += -std::copysign(resolution_ / 2.0, std::abs(shift.x()) < resolution_ / 2.0 ? -shift.x() : shift.x());
     }
     if (std::abs(shift.y()) < resolution_ / 2.0) {
       position_.y() -= shift.y();


### PR DESCRIPTION
run the following test code :
```
#include<ros/ros.h>
#include<grid_map_core/grid_map_core.hpp>

using namespace grid_map;

int main(int argc, char * argv[])
{
	GridMap map1({"elevation"});
	map1.setFrameId("map");
	map1.setGeometry(Length(1.5,1.5), 0.5);
	map1.add("elevation", 0.5);
	ROS_INFO("Before extend\nmap1:\nsize %i x %i\nposition %f, %f\n", map1.getSize().x(), map1.getSize().y(), map1.getPosition().x(), map1.getPosition().y());

        GridMap map2({"elevation"});
	map2.setFrameId("map");
	map2.setGeometry(Length(1.0,1.0), 0.5, Position(0.6, 0.25));
	map2.add("elevation", 1.0);
	ROS_INFO("map2:\nsize %i x %i\nposition %f, %f\n", map2.getSize().x(), map2.getSize().y(), map2.getPosition().x(), map2.getPosition().y());

	map1.extendToInclude(map2);
	ROS_INFO("After extend\nmap1:\nsize %i x %i\nposition %f, %f\n", map1.getSize().x(), map1.getSize().y(), map1.getPosition().x(), map1.getPosition().y());
	ROS_INFO("map2:\nsize %i x %i\nposition %f, %f\n", map2.getSize().x(), map2.getSize().y(), map2.getPosition().x(), map2.getPosition().y());

	return 0;
} 
```
the result is :
``` c++
[ INFO] [1542806189.388178709]: Before extend
map1:
size 3 x 3
position 0.000000, 0.000000

[ INFO] [1542806189.388209762]: map2:
size 2 x 2
position 0.600000, 0.250000

[ INFO] [1542806189.388244481]: After extend
map1:
size 4 x 3
position -0.250000, 0.000000

[ INFO] [1542806189.388251537]: map2:
size 2 x 2
position 0.600000, 0.250000
```
as we can see, the output of the position of the map1 in third [INFO] [1542806189.388244481] was wrong, it should be position 0.250000, 0.000000, not position -0.250000, 0.000000.