### PR TITLE
Feature/process bag srv

### DIFF
--- a/grid_map_msgs/CMakeLists.txt
+++ b/grid_map_msgs/CMakeLists.txt
@@ -24,6 +24,7 @@ add_service_files(
   FILES
   GetGridMap.srv
   GetGridMapInfo.srv
+  ProcessBag.srv
   ProcessFile.srv
 )
 
@@ -53,4 +54,3 @@ catkin_package(
         std_msgs
     #DEPENDS
 )
-

--- a/grid_map_msgs/srv/ProcessBag.srv
+++ b/grid_map_msgs/srv/ProcessBag.srv
@@ -1,7 +1,7 @@
 # Absolute file path of the rosbag.
 string file_path
 
-# Name of the topic in the ROS bag.
+# Name of the topic in the rosbag.
 string topic
 
 ---

--- a/grid_map_msgs/srv/ProcessBag.srv
+++ b/grid_map_msgs/srv/ProcessBag.srv
@@ -1,0 +1,10 @@
+# Absolute file path of the rosbag.
+string file_path
+
+# Name of the topic in the ROS bag.
+string topic
+
+---
+
+# True if file processing was successful.
+bool success


### PR DESCRIPTION
Functions [`saveToBag`](https://github.com/ANYbotics/grid_map/blob/master/grid_map_ros/include/grid_map_ros/GridMapRosConverter.hpp#L237) and [`loadFromBag`](https://github.com/ANYbotics/grid_map/blob/master/grid_map_ros/include/grid_map_ros/GridMapRosConverter.hpp#L247) from "GridMapRosConverter.hpp" require an absolute path of the rosbg and a topic name.
Service ['ProcessFile.srv'](https://github.com/ANYbotics/grid_map/blob/master/grid_map_msgs/srv/ProcessFile.srv) provides only the filed `file_path`, therefore a new service has been created to allow the specification of a topic name.