### PR TITLE
Extend ProcessFile.srv to include topic_name field.

### DIFF
--- a/grid_map_msgs/srv/ProcessFile.srv
+++ b/grid_map_msgs/srv/ProcessFile.srv
@@ -1,8 +1,8 @@
 # Absolute file path.
 string file_path
 
-# Topic name.
-string topic_name
+# For ROS bags: A list of topic names that should be processed (optional).
+string[] topic_names
 
 ---
 

--- a/grid_map_msgs/srv/ProcessFile.srv
+++ b/grid_map_msgs/srv/ProcessFile.srv
@@ -1,6 +1,9 @@
 # Absolute file path.
 string file_path
 
+# Topic name.
+string topic_name
+
 ---
 
 # True if file processing was successful.

--- a/grid_map_msgs/srv/ProcessFile.srv
+++ b/grid_map_msgs/srv/ProcessFile.srv
@@ -1,8 +1,8 @@
 # Absolute file path.
 string file_path
 
-# For ROS bags: A list of topic names that should be processed (optional).
-string[] topic_names
+# For ROS bags: topic name that should be processed (optional).
+string topic_name
 
 ---
 


### PR DESCRIPTION
Functions [`saveToBag`](https://github.com/ANYbotics/grid_map/blob/master/grid_map_ros/include/grid_map_ros/GridMapRosConverter.hpp#L237) and [`loadFromBag`](https://github.com/ANYbotics/grid_map/blob/master/grid_map_ros/include/grid_map_ros/GridMapRosConverter.hpp#L247) from "GridMapRosConverter.hpp" require an absolute path of the rosbg and a topic name.
Service ['ProcessFile.srv'](https://github.com/ANYbotics/grid_map/blob/master/grid_map_msgs/srv/ProcessFile.srv) is extended to allow the specification of a topic name.