### PR TITLE
Fix potential crash of rviz plugin in case of NAN values within the grid

### DIFF
--- a/grid_map_rviz_plugin/src/GridMapVisual.cpp
+++ b/grid_map_rviz_plugin/src/GridMapVisual.cpp
@@ -165,6 +165,11 @@ void GridMapVisual::computeVisualization(float alpha, bool showGridLines, bool f
         Ogre::Vector3 normal = vertices.size() == 4
                                ? (vertices[3] - vertices[0]).crossProduct(vertices[2] -vertices[1])
                                : (vertices[2] - vertices[1]).crossProduct(vertices[1] - vertices[0]);
+
+        if (!std::isfinite(normal[0]) || !std::isfinite(normal[1]) || !std::isfinite(normal[2])) {
+          continue;
+        }
+
         normal.normalise();
         // Create one or two triangles from the vertices depending on how many vertices we have.
         if (!noColor) {


### PR DESCRIPTION
We have observed sporadic crashes of rviz, when we are using grid maps containing some NAN values.

The error message is:
```rviz: /build/ogre-1.9-B6QkmW/ogre-1.9-1.9.0+dfsg1/OgreMain/include/OgreAxisAlignedBox.h:252: void Ogre::AxisAlignedBox::setExtents(const Ogre::Vector3&, const Ogre::Vector3&): Assertion `(min.x <= max.x && min.y <= max.y && min.z <= max.z) && "The minimum corner of the box must be less than or equal to maximum corner"' failed.```

This simple change fixes this problem.