### PR TITLE
[ROS2] grid_map_cv port (re-submission)

### DIFF
--- a/grid_map_core/CMakeLists.txt
+++ b/grid_map_core/CMakeLists.txt
@@ -128,8 +128,10 @@ if(TARGET ${PROJECT_NAME}-test)
   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories(include ${EIGEN3_INCLUDE_DIR})
 ament_export_libraries(
   ${PROJECT_NAME}
 )
-ament_package()
+ament_package(CONFIG_EXTRAS
+  cmake/${PROJECT_NAME}-extras.cmake
+)

--- a/grid_map_cv/CMakeLists.txt
+++ b/grid_map_cv/CMakeLists.txt
@@ -1,52 +1,39 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(grid_map_cv)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-
-## Find catkin macros and libraries
-find_package(catkin REQUIRED COMPONENTS
-  grid_map_core
-  cv_bridge
-  filters
-)
+## Find ament packages
+find_package(ament_cmake REQUIRED)
+find_package(grid_map_cmake_helpers REQUIRED)
+find_package(grid_map_core REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(filters REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
 
 find_package(OpenCV REQUIRED
   COMPONENTS
-  opencv_photo
+    opencv_photo
 )
 
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
-  INCLUDE_DIRS
-    include
-  LIBRARIES
-    ${PROJECT_NAME}
-  CATKIN_DEPENDS
-    grid_map_core
-    cv_bridge
-    filters
-  DEPENDS
-    OpenCV
+grid_map_package()
+
+## Specify additional locations of header files
+include_directories(
+  include
+)
+
+set(dependencies
+  grid_map_core
+  cv_bridge
+  filters
+  sensor_msgs
+  rclcpp
+  OpenCV
 )
 
 ###########
 ## Build ##
 ###########
-
-## Specify additional locations of header files
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIR}
-)
 
 ## Declare a cpp library
 add_library(${PROJECT_NAME}
@@ -54,13 +41,8 @@ add_library(${PROJECT_NAME}
   src/InpaintFilter.cpp
 )
 
-target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES}
-  ${OpenCV_LIBRARIES}
-)
-
-add_dependencies(${PROJECT_NAME}
-  ${catkin_EXPORTED_TARGETS}
+ament_target_dependencies(${PROJECT_NAME}
+  ${dependencies}
 )
 
 #############
@@ -70,38 +52,68 @@ add_dependencies(${PROJECT_NAME}
 # Mark executables and/or libraries for installation
 install(
   TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
 # Mark cpp header files for installation
 install(
   DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  DESTINATION include/${PROJECT_NAME}
   FILES_MATCHING PATTERN "*.hpp"
 )
 
 # Mark other files for installation.
 install(
   FILES filter_plugins.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  DESTINATION share/${PROJECT_NAME}
 )
 
 #############
 ## Testing ##
 #############
 
-if(CATKIN_ENABLE_TESTING)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-## Add gtest based cpp test target and link libraries
-catkin_add_gtest(${PROJECT_NAME}-test
-  test/test_grid_map_cv.cpp
-  test/GridMapCvTest.cpp
-  test/GridMapCvProcessingTest.cpp)
+if(BUILD_TESTING)
+  # Linting is setup this way to add a filter
+  # to ament_cpplint to ignore the lack of
+  # copyright messages at the top of files.
+  # Copyright messages are being checked for by both
+  # ament_cmake_cpplint & ament_cmake_copyright.
+
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_lint_auto QUIET)
+  if(ament_lint_auto_FOUND)
+    # exclude copyright checks
+    list(APPEND AMENT_LINT_AUTO_EXCLUDE
+      ament_cmake_cpplint
+      ament_cmake_copyright
+    )
+    ament_lint_auto_find_test_dependencies()
+
+    # run cpplint without copyright filter
+    find_package(ament_cmake_cpplint)
+    ament_cpplint(
+      FILTERS -legal/copyright
+    )
+  endif()
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ## Add gtest based cpp test target and link libraries
+  ament_add_gtest(${PROJECT_NAME}-test
+    test/test_grid_map_cv.cpp
+    test/GridMapCvTest.cpp
+    test/GridMapCvProcessingTest.cpp
+  )
 endif()
 
 if(TARGET ${PROJECT_NAME}-test)
   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 endif()
 
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+ament_export_dependencies(${dependencies})
+ament_package()

--- a/grid_map_cv/filter_plugins.xml
+++ b/grid_map_cv/filter_plugins.xml
@@ -1,6 +1,7 @@
 <class_libraries>
-  <library path="lib/libgrid_map_cv">
-    <class name="gridMapCv/InpaintFilter" type="grid_map::InpaintFilter<grid_map::GridMap>" base_class_type="filters::FilterBase<grid_map::GridMap>" >
+  <library path="grid_map_cv">
+  <!-- "<" is replaced with "&lt;" & ">" is replaced with "&gt" -->
+    <class name="gridMapCv/InpaintFilter" type="grid_map::InpaintFilter&lt;grid_map::GridMap&gt;" base_class_type="filters::FilterBase&lt;grid_map::GridMap&gt;">
       <description>
         Use OpenCV to inpaint/fill holes in a layer.
       </description>

--- a/grid_map_cv/include/grid_map_cv/GridMapCvConverter.hpp
+++ b/grid_map_cv/include/grid_map_cv/GridMapCvConverter.hpp
@@ -6,7 +6,8 @@
  *	 Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_CV__GRIDMAPCVCONVERTER_HPP_
+#define GRID_MAP_CV__GRIDMAPCVCONVERTER_HPP_
 
 #include <grid_map_core/grid_map_core.hpp>
 
@@ -16,14 +17,18 @@
 // STD
 #include <iostream>
 
-namespace grid_map {
+#include <string>
+#include <limits>
+
+namespace grid_map
+{
 
 /*!
  * Conversions between grid maps and OpenCV images.
  */
 class GridMapCvConverter
 {
- public:
+public:
   /*!
    * Initializes the geometry of a grid map from an image. This changes
    * the geometry of the map and deletes all contents of the layers!
@@ -33,8 +38,9 @@ class GridMapCvConverter
    * @param[in](optional) position the position of the grid map.
    * @return true if successful, false otherwise.
    */
-  static bool initializeFromImage(const cv::Mat& image, const double resolution,
-                                  grid_map::GridMap& gridMap, const grid_map::Position& position)
+  static bool initializeFromImage(
+    const cv::Mat & image, const double resolution,
+    grid_map::GridMap & gridMap, const grid_map::Position & position)
   {
     const double lengthX = resolution * image.rows;
     const double lengthY = resolution * image.cols;
@@ -56,9 +62,10 @@ class GridMapCvConverter
    * @return true if successful, false otherwise.
    */
   template<typename Type_, int NChannels_>
-  static bool addLayerFromImage(const cv::Mat& image, const std::string& layer,
-                                grid_map::GridMap& gridMap, const float lowerValue = 0.0,
-                                const float upperValue = 1.0, const double alphaThreshold = 0.5)
+  static bool addLayerFromImage(
+    const cv::Mat & image, const std::string & layer,
+    grid_map::GridMap & gridMap, const float lowerValue = 0.0,
+    const float upperValue = 1.0, const double alphaThreshold = 0.5)
   {
     if (gridMap.getSize()(0) != image.rows || gridMap.getSize()(1) != image.cols) {
       std::cerr << "Image size does not correspond to grid map size!" << std::endl;
@@ -66,16 +73,16 @@ class GridMapCvConverter
     }
 
     bool isColor = false;
-    if (image.channels() >= 3) isColor = true;
+    if (image.channels() >= 3) {isColor = true;}
     bool hasAlpha = false;
-    if (image.channels() >= 4) hasAlpha = true;
+    if (image.channels() >= 4) {hasAlpha = true;}
 
     cv::Mat imageMono;
     if (isColor && !hasAlpha) {
       cv::cvtColor(image, imageMono, CV_BGR2GRAY);
     } else if (isColor && hasAlpha) {
       cv::cvtColor(image, imageMono, CV_BGRA2GRAY);
-    } else if (!isColor && !hasAlpha){
+    } else if (!isColor && !hasAlpha) {
       imageMono = image;
     } else {
       std::cerr << "Something went wrong when adding grid map layer form image!" << std::endl;
@@ -87,8 +94,8 @@ class GridMapCvConverter
     float maxImageValue;
     if (std::is_same<Type_, float>::value || std::is_same<Type_, double>::value) {
       maxImageValue = 1.0;
-    } else if (std::is_same<Type_, unsigned short>::value || std::is_same<Type_, unsigned char>::value) {
-      maxImageValue = (float)std::numeric_limits<Type_>::max();
+    } else if (std::is_same<Type_, uint16_t>::value || std::is_same<Type_, unsigned char>::value) {
+      maxImageValue = static_cast<float>(std::numeric_limits<Type_>::max());
     } else {
       std::cerr << "This image type is not supported." << std::endl;
       return false;
@@ -97,25 +104,27 @@ class GridMapCvConverter
     const Type_ alphaTreshold = (Type_)(alphaThreshold * maxImageValue);
 
     gridMap.add(layer);
-    grid_map::Matrix& data = gridMap[layer];
+    grid_map::Matrix & data = gridMap[layer];
 
     for (GridMapIterator iterator(gridMap); !iterator.isPastEnd(); ++iterator) {
       const Index index(*iterator);
 
       // Check for alpha layer.
       if (hasAlpha) {
-        const Type_ alpha = image.at<cv::Vec<Type_, NChannels_>>(index(0), index(1))[NChannels_ - 1];
-        if (alpha < alphaTreshold) continue;
+        const Type_ alpha =
+          image.at<cv::Vec<Type_, NChannels_>>(index(0), index(1))[NChannels_ - 1];
+        if (alpha < alphaTreshold) {continue;}
       }
 
       // Compute value.
       const Type_ imageValue = imageMono.at<Type_>(index(0), index(1));
-      const float mapValue = lowerValue + mapValueDifference * ((float) imageValue / maxImageValue);
+      const float mapValue = lowerValue + mapValueDifference *
+        (static_cast<float>(imageValue) / maxImageValue);
       data(index(0), index(1)) = mapValue;
     }
 
     return true;
-  };
+  }
 
   /*!
    * Adds a color layer with data from an image.
@@ -125,8 +134,9 @@ class GridMapCvConverter
    * @return true if successful, false otherwise.
    */
   template<typename Type_, int NChannels_>
-  static bool addColorLayerFromImage(const cv::Mat& image, const std::string& layer,
-                                     grid_map::GridMap& gridMap)
+  static bool addColorLayerFromImage(
+    const cv::Mat & image, const std::string & layer,
+    grid_map::GridMap & gridMap)
   {
     if (gridMap.getSize()(0) != image.rows || gridMap.getSize()(1) != image.cols) {
       std::cerr << "Image size does not correspond to grid map size!" << std::endl;
@@ -134,7 +144,7 @@ class GridMapCvConverter
     }
 
     bool hasAlpha = false;
-    if (image.channels() >= 4) hasAlpha = true;
+    if (image.channels() >= 4) {hasAlpha = true;}
 
     cv::Mat imageRGB;
     if (hasAlpha) {
@@ -146,7 +156,7 @@ class GridMapCvConverter
     gridMap.add(layer);
 
     for (GridMapIterator iterator(gridMap); !iterator.isPastEnd(); ++iterator) {
-      const auto& cvColor = imageRGB.at<cv::Vec<Type_, 3>>((*iterator)(0), (*iterator)(1));
+      const auto & cvColor = imageRGB.at<cv::Vec<Type_, 3>>((*iterator)(0), (*iterator)(1));
       Eigen::Vector3i colorVector;
       colorVector(0) = cvColor[0];
       colorVector(1) = cvColor[1];
@@ -170,13 +180,14 @@ class GridMapCvConverter
    * @return true if successful, false otherwise.
    */
   template<typename Type_, int NChannels_>
-  static bool toImage(const grid_map::GridMap& gridMap, const std::string& layer,
-                      const int encoding, cv::Mat& image)
+  static bool toImage(
+    const grid_map::GridMap & gridMap, const std::string & layer,
+    const int encoding, cv::Mat & image)
   {
     const float minValue = gridMap.get(layer).minCoeffOfFinites();
     const float maxValue = gridMap.get(layer).maxCoeffOfFinites();
     return toImage<Type_, NChannels_>(gridMap, layer, encoding, minValue, maxValue, image);
-  };
+  }
 
   /*!
    * Creates a cv mat from a grid map layer.
@@ -189,9 +200,10 @@ class GridMapCvConverter
    * @return true if successful, false otherwise.
    */
   template<typename Type_, int NChannels_>
-  static bool toImage(const grid_map::GridMap& gridMap, const std::string& layer,
-                      const int encoding, const float lowerValue, const float upperValue,
-                      cv::Mat& image)
+  static bool toImage(
+    const grid_map::GridMap & gridMap, const std::string & layer,
+    const int encoding, const float lowerValue, const float upperValue,
+    cv::Mat & image)
   {
     // Initialize image.
     if (gridMap.getSize()(0) > 0 && gridMap.getSize()(1) > 0) {
@@ -205,7 +217,7 @@ class GridMapCvConverter
     Type_ imageMax;
     if (std::is_same<Type_, float>::value || std::is_same<Type_, double>::value) {
       imageMax = 1.0;
-    } else if (std::is_same<Type_, unsigned short>::value || std::is_same<Type_, unsigned char>::value) {
+    } else if (std::is_same<Type_, uint16_t>::value || std::is_same<Type_, unsigned char>::value) {
       imageMax = (Type_)std::numeric_limits<Type_>::max();
     } else {
       std::cerr << "This image type is not supported." << std::endl;
@@ -215,36 +227,41 @@ class GridMapCvConverter
     // Clamp outliers.
     grid_map::GridMap map = gridMap;
     map.get(layer) = map.get(layer).unaryExpr(grid_map::Clamp<float>(lowerValue, upperValue));
-    const grid_map::Matrix& data = map[layer];
+    const grid_map::Matrix & data = map[layer];
 
     // Convert to image.
     bool isColor = false;
-    if (image.channels() >= 3) isColor = true;
+    if (image.channels() >= 3) {isColor = true;}
     bool hasAlpha = false;
-    if (image.channels() >= 4) hasAlpha = true;
+    if (image.channels() >= 4) {hasAlpha = true;}
 
     for (GridMapIterator iterator(map); !iterator.isPastEnd(); ++iterator) {
       const Index index(*iterator);
       if (std::isfinite(data(index(0), index(1)))) {
-        const float& value = data(index(0), index(1));
-        const Type_ imageValue = (Type_) (((value - lowerValue) / (upperValue - lowerValue)) * (float) imageMax);
+        const float & value = data(index(0), index(1));
+        const Type_ imageValue =
+          (Type_) (((value - lowerValue) / (upperValue - lowerValue)) *
+          static_cast<float>(imageMax));
         const Index imageIndex(iterator.getUnwrappedIndex());
         unsigned int channel = 0;
         image.at<cv::Vec<Type_, NChannels_>>(imageIndex(0), imageIndex(1))[channel] = imageValue;
 
         if (isColor) {
-          image.at<cv::Vec<Type_, NChannels_>>(imageIndex(0), imageIndex(1))[++channel] = imageValue;
-          image.at<cv::Vec<Type_, NChannels_>>(imageIndex(0), imageIndex(1))[++channel] = imageValue;
+          image.at<cv::Vec<Type_, NChannels_>>(
+            imageIndex(0),
+            imageIndex(1))[++channel] = imageValue;
+          image.at<cv::Vec<Type_, NChannels_>>(
+            imageIndex(0),
+            imageIndex(1))[++channel] = imageValue;
         }
         if (hasAlpha) {
           image.at<cv::Vec<Type_, NChannels_>>(imageIndex(0), imageIndex(1))[++channel] = imageMax;
         }
       }
     }
-
     return true;
-  };
-
+  }
 };
 
-} /* namespace */
+}  // namespace grid_map
+#endif  // GRID_MAP_CV__GRIDMAPCVCONVERTER_HPP_

--- a/grid_map_cv/include/grid_map_cv/GridMapCvProcessing.hpp
+++ b/grid_map_cv/include/grid_map_cv/GridMapCvProcessing.hpp
@@ -6,21 +6,23 @@
  *	 Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_CV__GRIDMAPCVPROCESSING_HPP_
+#define GRID_MAP_CV__GRIDMAPCVPROCESSING_HPP_
 
 #include <grid_map_core/grid_map_core.hpp>
 
 // OpenCV
 #include <cv_bridge/cv_bridge.h>
 
-namespace grid_map {
+namespace grid_map
+{
 
 /*!
  * Processing of grid maps with OpenCV methods.
  */
 class GridMapCvProcessing
 {
- public:
+public:
   /*!
    * Default constructor.
    */
@@ -39,11 +41,12 @@ class GridMapCvProcessing
    * @param[in](optional) interpolationAlgorithm the interpolation method.
    * @return true if successful, false otherwise.
    */
-  static bool changeResolution(const GridMap& gridMapSource,
-                               GridMap& gridMapResult,
-                               const double resolution,
-                               const int interpolationAlgorithm = cv::INTER_CUBIC);
-
+  static bool changeResolution(
+    const grid_map::GridMap & gridMapSource,
+    grid_map::GridMap & gridMapResult,
+    const double resolution,
+    const int interpolationAlgorithm = cv::INTER_CUBIC);
 };
 
-} /* namespace */
+}  // namespace grid_map
+#endif  // GRID_MAP_CV__GRIDMAPCVPROCESSING_HPP_

--- a/grid_map_cv/include/grid_map_cv/InpaintFilter.hpp
+++ b/grid_map_cv/include/grid_map_cv/InpaintFilter.hpp
@@ -6,26 +6,28 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_CV__INPAINTFILTER_HPP_
+#define GRID_MAP_CV__INPAINTFILTER_HPP_
 
-#include <filters/filter_base.h>
-
-//OpenCV
-#include "grid_map_cv/grid_map_cv.hpp"
+#include <filters/filter_base.hpp>
 #include <opencv2/opencv.hpp>
 
 #include <vector>
 #include <string>
 
-namespace grid_map {
+// OpenCV
+#include "grid_map_cv/grid_map_cv.hpp"
+
+namespace grid_map
+{
 
 /*!
  * Uses OpenCV function to inpaint/fill holes in the input layer.
  */
 template<typename T>
-class InpaintFilter : public filters::FilterBase<T> {
-
- public:
+class InpaintFilter : public filters::FilterBase<T>
+{
+public:
   /*!
    * Constructor
    */
@@ -48,10 +50,9 @@ class InpaintFilter : public filters::FilterBase<T> {
    * @param mapIn grid map containing input layer
    * @param mapOut grid map containing mapIn and inpainted input layer.
    */
-  virtual bool update(const T& mapIn, T& mapOut);
+  virtual bool update(const T & mapIn, T & mapOut);
 
- private:
-
+private:
   //! Inpainting radius.
   double radius_;
 
@@ -62,4 +63,5 @@ class InpaintFilter : public filters::FilterBase<T> {
   std::string outputLayer_;
 };
 
-} /* namespace */
+}  // namespace grid_map
+#endif  // GRID_MAP_CV__INPAINTFILTER_HPP_

--- a/grid_map_cv/include/grid_map_cv/grid_map_cv.hpp
+++ b/grid_map_cv/include/grid_map_cv/grid_map_cv.hpp
@@ -6,8 +6,10 @@
  *	 Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_CV__GRID_MAP_CV_HPP_
+#define GRID_MAP_CV__GRID_MAP_CV_HPP_
 
 #include <grid_map_core/grid_map_core.hpp>
 #include <grid_map_cv/GridMapCvConverter.hpp>
 #include <grid_map_cv/GridMapCvProcessing.hpp>
+#endif  // GRID_MAP_CV__GRID_MAP_CV_HPP_

--- a/grid_map_cv/package.xml
+++ b/grid_map_cv/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>grid_map_cv</name>
-  <version>1.6.2</version>
+  <version>2.0.0</version>
   <description>Conversions between grid maps and OpenCV images.</description>
   <maintainer email="mwulf@anybotics.com">Maximilian Wulf</maintainer>
   <maintainer email="ynava@anybotics.com">Yoshua Nava</maintainer>
@@ -9,11 +9,21 @@
   <url type="website">http://github.com/anybotics/grid_map</url>
   <url type="bugtracker">http://github.com/anybotics/grid_map/issues</url>
   <author email="pfankhauser@anybotics.com">Péter Fankhauser</author>
-  <buildtool_depend>catkin</buildtool_depend>
+  
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>grid_map_cmake_helpers</build_depend>
+  
   <depend>grid_map_core</depend>
   <depend>cv_bridge</depend>
   <depend>filters</depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
+    <build_type>ament_cmake</build_type>
     <filters plugin="${prefix}/filter_plugins.xml" />
   </export>
 </package>

--- a/grid_map_cv/src/GridMapCvProcessing.cpp
+++ b/grid_map_cv/src/GridMapCvProcessing.cpp
@@ -9,7 +9,8 @@
 #include "grid_map_cv/GridMapCvProcessing.hpp"
 #include "grid_map_cv/GridMapCvConverter.hpp"
 
-namespace grid_map {
+namespace grid_map
+{
 
 GridMapCvProcessing::GridMapCvProcessing()
 {
@@ -19,39 +20,58 @@ GridMapCvProcessing::~GridMapCvProcessing()
 {
 }
 
-bool GridMapCvProcessing::changeResolution(const GridMap& gridMapSource,
-                             GridMap& gridMapResult,
-                             const double resolution,
-                             const int interpolationAlgorithm)
+bool GridMapCvProcessing::changeResolution(
+  const grid_map::GridMap & gridMapSource,
+  grid_map::GridMap & gridMapResult,
+  const double resolution,
+  const int interpolationAlgorithm)
 {
-  GridMap gridMapSourceCopy(gridMapSource);
+  grid_map::GridMap gridMapSourceCopy(gridMapSource);
   gridMapSourceCopy.convertToDefaultStartIndex();
   const double sizeFactor = gridMapSourceCopy.getResolution() / resolution;
   bool firstLayer = true;
-  for (const auto& layer : gridMapSourceCopy.getLayers()) {
+  for (const auto & layer : gridMapSourceCopy.getLayers()) {
     cv::Mat imageSource, imageResult;
     const float minValue = gridMapSourceCopy.get(layer).minCoeffOfFinites();
     const float maxValue = gridMapSourceCopy.get(layer).maxCoeffOfFinites();
     const bool hasNaN = gridMapSourceCopy.get(layer).hasNaN();
     bool result;
     if (hasNaN) {
-      result = GridMapCvConverter::toImage<unsigned short, 4>(gridMapSourceCopy, layer, CV_16UC4, minValue, maxValue, imageSource);
+      result = grid_map::GridMapCvConverter::toImage<uint16_t, 4>(
+        gridMapSourceCopy, layer, CV_16UC4,
+        minValue, maxValue, imageSource);
     } else {
-      result = GridMapCvConverter::toImage<unsigned short, 1>(gridMapSourceCopy, layer, CV_16UC1, minValue, maxValue, imageSource);
+      result = grid_map::GridMapCvConverter::toImage<uint16_t, 1>(
+        gridMapSourceCopy, layer, CV_16UC1,
+        minValue, maxValue, imageSource);
     }
-    if (!result) return false;
-    cv::resize(imageSource, imageResult, cv::Size(0.0, 0.0), sizeFactor, sizeFactor, interpolationAlgorithm);
+    if (!result) {return false;}
+    cv::resize(
+      imageSource, imageResult, cv::Size(
+        0.0,
+        0.0), sizeFactor, sizeFactor,
+      interpolationAlgorithm);
     if (firstLayer) {
-      if (!GridMapCvConverter::initializeFromImage(imageResult, resolution, gridMapResult, gridMapSourceCopy.getPosition()))
+      if (!GridMapCvConverter::initializeFromImage(
+          imageResult, resolution, gridMapResult,
+          gridMapSourceCopy.getPosition()))
+      {
         return false;
+      }
       firstLayer = false;
     }
     if (hasNaN) {
-      result = GridMapCvConverter::addLayerFromImage<unsigned short, 4>(imageResult, layer, gridMapResult, minValue, maxValue);
+      result = grid_map::GridMapCvConverter::addLayerFromImage<uint16_t, 4>(
+        imageResult, layer,
+        gridMapResult, minValue,
+        maxValue);
     } else {
-      result = GridMapCvConverter::addLayerFromImage<unsigned short, 1>(imageResult, layer, gridMapResult, minValue, maxValue);
+      result = grid_map::GridMapCvConverter::addLayerFromImage<uint16_t, 1>(
+        imageResult, layer,
+        gridMapResult, minValue,
+        maxValue);
     }
-    if (!result) return false;
+    if (!result) {return false;}
   }
   gridMapResult.setFrameId(gridMapSourceCopy.getFrameId());
   gridMapResult.setTimestamp(gridMapSourceCopy.getTimestamp());
@@ -59,4 +79,4 @@ bool GridMapCvProcessing::changeResolution(const GridMap& gridMapSource,
   return true;
 }
 
-} /* namespace */
+}  // namespace grid_map

--- a/grid_map_cv/src/InpaintFilter.cpp
+++ b/grid_map_cv/src/InpaintFilter.cpp
@@ -7,66 +7,77 @@
  */
 
 #include "grid_map_cv/InpaintFilter.hpp"
-#include <pluginlib/class_list_macros.h>
-#include <ros/ros.h>
+#include <pluginlib/class_list_macros.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 // Grid Map
 #include <grid_map_core/grid_map_core.hpp>
 
-using namespace filters;
+#include <string>
+#include <vector>
 
-namespace grid_map {
+namespace grid_map
+{
 
 template<typename T>
 InpaintFilter<T>::InpaintFilter()
-    : radius_(5.0) {
-
+: radius_(5.0)
+{
 }
 
 template<typename T>
-InpaintFilter<T>::~InpaintFilter() {
-
+InpaintFilter<T>::~InpaintFilter()
+{
 }
 
 template<typename T>
-bool InpaintFilter<T>::configure() {
-  if (!FilterBase < T > ::getParam(std::string("radius"), radius_)) {
-    ROS_ERROR("InpaintRadius filter did not find param radius.");
+bool InpaintFilter<T>::configure()
+{
+  if (!filters::FilterBase<T>::getParam(std::string("radius"), radius_)) {
+    RCLCPP_ERROR(
+      this->logging_interface_->get_logger(), "InpaintRadius filter did not find param radius.");
     return false;
   }
 
   if (radius_ < 0.0) {
-    ROS_ERROR("Radius must be greater than zero.");
+    RCLCPP_ERROR(this->logging_interface_->get_logger(), "Radius must be greater than zero.");
     return false;
   }
 
-  ROS_DEBUG("Radius = %f.", radius_);
+  RCLCPP_DEBUG(this->logging_interface_->get_logger(), "Radius = %f.", radius_);
 
-  if (!FilterBase < T > ::getParam(std::string("input_layer"), inputLayer_)) {
-    ROS_ERROR("Inpaint filter did not find parameter `input_layer`.");
+  if (!filters::FilterBase<T>::getParam(std::string("input_layer"), inputLayer_)) {
+    RCLCPP_ERROR(
+      this->logging_interface_->get_logger(),
+      "Inpaint filter did not find parameter `input_layer`.");
     return false;
   }
 
-  ROS_DEBUG("Inpaint input layer is = %s.", inputLayer_.c_str());
+  RCLCPP_DEBUG(
+    this->logging_interface_->get_logger(), "Inpaint input layer is = %s.", inputLayer_.c_str());
 
-  if (!FilterBase < T > ::getParam(std::string("output_layer"), outputLayer_)) {
-    ROS_ERROR("Inpaint filter did not find parameter `output_layer`.");
+  if (!filters::FilterBase<T>::getParam(std::string("output_layer"), outputLayer_)) {
+    RCLCPP_ERROR(
+      this->logging_interface_->get_logger(),
+      "Inpaint filter did not find parameter `output_layer`.");
     return false;
   }
 
-  ROS_DEBUG("Inpaint output layer = %s.", outputLayer_.c_str());
+  RCLCPP_DEBUG(
+    this->logging_interface_->get_logger(), "Inpaint output layer = %s.", outputLayer_.c_str());
 
   return true;
 }
 
 template<typename T>
-bool InpaintFilter<T>::update(const T& mapIn, T& mapOut) {
+bool InpaintFilter<T>::update(const T & mapIn, T & mapOut)
+{
   // Add new layer to the elevation map.
   mapOut = mapIn;
   mapOut.add(outputLayer_);
 
-  //Convert elevation layer to OpenCV image to fill in holes.
-  //Get the inpaint mask (nonzero pixels indicate where values need to be filled in).
+  // Convert elevation layer to OpenCV image to fill in holes.
+  // Get the inpaint mask (nonzero pixels indicate where values need to be filled in).
   mapOut.add("inpaint_mask", 0.0);
 
   mapOut.setBasicLayers(std::vector<std::string>());
@@ -81,19 +92,24 @@ bool InpaintFilter<T>::update(const T& mapIn, T& mapOut) {
   const float minValue = mapOut.get(inputLayer_).minCoeffOfFinites();
   const float maxValue = mapOut.get(inputLayer_).maxCoeffOfFinites();
 
-  grid_map::GridMapCvConverter::toImage<unsigned char, 3>(mapOut, inputLayer_, CV_8UC3, minValue, maxValue,
-                                                          originalImage);
+  grid_map::GridMapCvConverter::toImage<unsigned char, 3>(
+    mapOut, inputLayer_, CV_8UC3, minValue, maxValue,
+    originalImage);
   grid_map::GridMapCvConverter::toImage<unsigned char, 1>(mapOut, "inpaint_mask", CV_8UC1, mask);
 
   const double radiusInPixels = radius_ / mapIn.getResolution();
   cv::inpaint(originalImage, mask, filledImage, radiusInPixels, cv::INPAINT_NS);
 
-  grid_map::GridMapCvConverter::addLayerFromImage<unsigned char, 3>(filledImage, outputLayer_, mapOut, minValue, maxValue);
+  grid_map::GridMapCvConverter::addLayerFromImage<unsigned char, 3>(
+    filledImage, outputLayer_,
+    mapOut, minValue, maxValue);
   mapOut.erase("inpaint_mask");
 
   return true;
 }
 
-}/* namespace */
+}  // namespace grid_map
 
-PLUGINLIB_EXPORT_CLASS(grid_map::InpaintFilter<grid_map::GridMap>, filters::FilterBase<grid_map::GridMap>)
+PLUGINLIB_EXPORT_CLASS(
+  grid_map::InpaintFilter<grid_map::GridMap>,
+  filters::FilterBase<grid_map::GridMap>)

--- a/grid_map_cv/test/GridMapCvProcessingTest.cpp
+++ b/grid_map_cv/test/GridMapCvProcessingTest.cpp
@@ -5,48 +5,49 @@
  *      Author: Peter Fankhauser
  */
 
-#include "grid_map_cv/grid_map_cv.hpp"
-
 #include <grid_map_core/grid_map_core.hpp>
 #include <grid_map_core/gtest_eigen.hpp>
-
-// gtest
-#include <gtest/gtest.h>
 
 // OpenCV
 #include <cv_bridge/cv_bridge.h>
 
-using namespace std;
-using namespace grid_map;
+// gtest
+#include <gtest/gtest.h>
+
+#include "grid_map_cv/grid_map_cv.hpp"
 
 TEST(GridMapCvProcessing, changeResolution)
 {
   // Create grid map.
-  GridMap mapIn;
+  grid_map::GridMap mapIn;
   mapIn.setGeometry(grid_map::Length(2.0, 1.0), 0.01);
   mapIn.add("layer", 1.0);
-  for (grid_map::CircleIterator iterator(mapIn, mapIn.getPosition(), 0.2); !iterator.isPastEnd(); ++iterator) {
+  for (grid_map::CircleIterator iterator(mapIn, mapIn.getPosition(), 0.2); !iterator.isPastEnd();
+    ++iterator)
+  {
     mapIn.at("layer", *iterator) = 2.0;
   }
 
   // Change resolution.
-  GridMap mapOut;
-  EXPECT_TRUE(GridMapCvProcessing::changeResolution(mapIn, mapOut, 0.1));
+  grid_map::GridMap mapOut;
+  EXPECT_TRUE(grid_map::GridMapCvProcessing::changeResolution(mapIn, mapOut, 0.1));
 
   // Check data.
   EXPECT_TRUE((mapIn.getLength() == mapOut.getLength()).all());
   EXPECT_TRUE(mapIn.getPosition() == mapOut.getPosition());
   EXPECT_TRUE((mapIn.getSize() == mapOut.getSize() * 10).all());
-  EXPECT_EQ(mapIn["layer"](0, 0), mapOut["layer"](0, 0)); // Corner.
-  EXPECT_EQ(mapIn.atPosition("layer", mapIn.getPosition()), mapOut.atPosition("layer", mapOut.getPosition())); // Center.
+  EXPECT_EQ(mapIn["layer"](0, 0), mapOut["layer"](0, 0));  // Corner.
+  EXPECT_EQ(
+    mapIn.atPosition("layer", mapIn.getPosition()),
+    mapOut.atPosition("layer", mapOut.getPosition()));  // Center.
 }
 
 TEST(GridMapCvProcessing, changeResolutionForMovedMap)
 {
   // Create grid map.
-  GridMap mapIn;
+  grid_map::GridMap mapIn;
   mapIn.setGeometry(grid_map::Length(2.0, 1.0), 0.01);
-  Position position(0.3, 0.4);
+  grid_map::Position position(0.3, 0.4);
   mapIn.move(position);
   mapIn.add("layer", 1.0);
   for (grid_map::CircleIterator iterator(mapIn, position, 0.2); !iterator.isPastEnd(); ++iterator) {
@@ -54,13 +55,15 @@ TEST(GridMapCvProcessing, changeResolutionForMovedMap)
   }
 
   // Change resolution.
-  GridMap mapOut;
-  EXPECT_TRUE(GridMapCvProcessing::changeResolution(mapIn, mapOut, 0.1));
+  grid_map::GridMap mapOut;
+  EXPECT_TRUE(grid_map::GridMapCvProcessing::changeResolution(mapIn, mapOut, 0.1));
 
   // Check data.
   EXPECT_TRUE((mapIn.getLength() == mapOut.getLength()).all());
   EXPECT_TRUE(mapIn.getPosition() == mapOut.getPosition());
   EXPECT_TRUE((mapIn.getSize() == mapOut.getSize() * 10).all());
-  EXPECT_EQ(mapIn["layer"](0, 0), mapOut["layer"](0, 0)); // Corner.
-  EXPECT_EQ(mapIn.atPosition("layer", mapIn.getPosition()), mapOut.atPosition("layer", mapOut.getPosition())); // Center.
+  EXPECT_EQ(mapIn["layer"](0, 0), mapOut["layer"](0, 0));  // Corner.
+  EXPECT_EQ(
+    mapIn.atPosition("layer", mapIn.getPosition()),
+    mapOut.atPosition("layer", mapOut.getPosition()));  // Center.
 }

--- a/grid_map_cv/test/GridMapCvTest.cpp
+++ b/grid_map_cv/test/GridMapCvTest.cpp
@@ -6,24 +6,24 @@
  *	 Institute: ETH Zurich, ANYbotics
  */
 
-#include "grid_map_cv/grid_map_cv.hpp"
-
 #include <grid_map_core/grid_map_core.hpp>
 #include <grid_map_core/gtest_eigen.hpp>
-
-// gtest
-#include <gtest/gtest.h>
 
 // OpenCV
 #include <cv_bridge/cv_bridge.h>
 
-using namespace std;
-using namespace grid_map;
+// gtest
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "grid_map_cv/grid_map_cv.hpp"
+
 
 TEST(ImageConversion, roundTrip8UC3)
 {
   // Create grid map.
-  GridMap mapIn({"layer"});
+  grid_map::GridMap mapIn({"layer"});
   mapIn.setGeometry(grid_map::Length(2.0, 1.0), 0.01);
   mapIn["layer"].setRandom();
   const float minValue = -1.0;
@@ -31,16 +31,21 @@ TEST(ImageConversion, roundTrip8UC3)
 
   // Convert to image.
   cv::Mat image;
-  GridMapCvConverter::toImage<unsigned char, 3>(mapIn, "layer", CV_8UC3, minValue, maxValue, image);
+  grid_map::GridMapCvConverter::toImage<unsigned char, 3>(
+    mapIn, "layer", CV_8UC3, minValue,
+    maxValue, image);
 
   // Convert back to grid map.
-  GridMap mapOut(mapIn);
+  grid_map::GridMap mapOut(mapIn);
   mapOut["layer"].setConstant(NAN);
-  GridMapCvConverter::addLayerFromImage<unsigned char, 3>(image, "layer", mapOut, minValue, maxValue);
+  grid_map::GridMapCvConverter::addLayerFromImage<unsigned char, 3>(
+    image, "layer", mapOut, minValue,
+    maxValue);
 
   // Check data.
-  const float resolution = (maxValue - minValue) / (float) std::numeric_limits<unsigned char>::max();
-  expectNear(mapIn["layer"], mapOut["layer"], resolution, "");
+  const float resolution = (maxValue - minValue) /
+    static_cast<float>(std::numeric_limits<unsigned char>::max());
+  grid_map::expectNear(mapIn["layer"], mapOut["layer"], resolution, "");
   EXPECT_TRUE((mapIn.getLength() == mapOut.getLength()).all());
   EXPECT_TRUE((mapIn.getSize() == mapOut.getSize()).all());
 }
@@ -48,25 +53,30 @@ TEST(ImageConversion, roundTrip8UC3)
 TEST(ImageConversion, roundTrip8UC4)
 {
   // Create grid map.
-  GridMap mapIn({"layer"});
+  grid_map::GridMap mapIn({"layer"});
   mapIn.setGeometry(grid_map::Length(2.0, 1.0), 0.1);
   mapIn["layer"].setRandom();
-  mapIn["layer"](1, 2) = NAN; // To check for transparnecy/nan handling.
+  mapIn["layer"](1, 2) = NAN;  // To check for transparnecy/nan handling.
   const float minValue = -1.0;
   const float maxValue = 1.0;
 
   // Convert to image.
   cv::Mat image;
-  GridMapCvConverter::toImage<unsigned char, 4>(mapIn, "layer", CV_8UC4, minValue, maxValue, image);
+  grid_map::GridMapCvConverter::toImage<unsigned char, 4>(
+    mapIn, "layer", CV_8UC4, minValue,
+    maxValue, image);
 
   // Convert back to grid map.
-  GridMap mapOut(mapIn);
+  grid_map::GridMap mapOut(mapIn);
   mapOut["layer"].setConstant(NAN);
-  GridMapCvConverter::addLayerFromImage<unsigned char, 4>(image, "layer", mapOut, minValue, maxValue);
+  grid_map::GridMapCvConverter::addLayerFromImage<unsigned char, 4>(
+    image, "layer", mapOut, minValue,
+    maxValue);
 
   // Check data.
-  const float resolution = (maxValue - minValue) / (float) std::numeric_limits<unsigned char>::max();
-  expectNear(mapIn["layer"], mapOut["layer"], resolution, "");
+  const float resolution = (maxValue - minValue) /
+    static_cast<float>(std::numeric_limits<unsigned char>::max());
+  grid_map::expectNear(mapIn["layer"], mapOut["layer"], resolution, "");
   EXPECT_TRUE((mapIn.getLength() == mapOut.getLength()).all());
   EXPECT_TRUE((mapIn.getSize() == mapOut.getSize()).all());
 }
@@ -74,7 +84,7 @@ TEST(ImageConversion, roundTrip8UC4)
 TEST(ImageConversion, roundTrip16UC1)
 {
   // Create grid map.
-  GridMap mapIn({"layer"});
+  grid_map::GridMap mapIn({"layer"});
   mapIn.setGeometry(grid_map::Length(2.0, 1.0), 0.01);
   mapIn["layer"].setRandom();
   const float minValue = -1.0;
@@ -82,16 +92,21 @@ TEST(ImageConversion, roundTrip16UC1)
 
   // Convert to image.
   cv::Mat image;
-  GridMapCvConverter::toImage<unsigned short, 1>(mapIn, "layer", CV_16UC1, minValue, maxValue, image);
+  grid_map::GridMapCvConverter::toImage<uint16_t, 1>(
+    mapIn, "layer", CV_16UC1, minValue, maxValue,
+    image);
 
   // Convert back to grid map.
-  GridMap mapOut(mapIn);
+  grid_map::GridMap mapOut(mapIn);
   mapOut["layer"].setConstant(NAN);
-  GridMapCvConverter::addLayerFromImage<unsigned short, 1>(image, "layer", mapOut, minValue, maxValue);
+  grid_map::GridMapCvConverter::addLayerFromImage<uint16_t, 1>(
+    image, "layer", mapOut, minValue,
+    maxValue);
 
   // Check data.
-  const float resolution = (maxValue - minValue) / (float) std::numeric_limits<unsigned char>::max();
-  expectNear(mapIn["layer"], mapOut["layer"], resolution, "");
+  const float resolution = (maxValue - minValue) /
+    static_cast<float>(std::numeric_limits<unsigned char>::max());
+  grid_map::expectNear(mapIn["layer"], mapOut["layer"], resolution, "");
   EXPECT_TRUE((mapIn.getLength() == mapOut.getLength()).all());
   EXPECT_TRUE((mapIn.getSize() == mapOut.getSize()).all());
 }
@@ -99,7 +114,7 @@ TEST(ImageConversion, roundTrip16UC1)
 TEST(ImageConversion, roundTrip32FC1)
 {
   // Create grid map.
-  GridMap mapIn({"layer"});
+  grid_map::GridMap mapIn({"layer"});
   mapIn.setGeometry(grid_map::Length(2.0, 1.0), 0.01);
   mapIn["layer"].setRandom();
   const float minValue = -1.0;
@@ -107,16 +122,21 @@ TEST(ImageConversion, roundTrip32FC1)
 
   // Convert to image.
   cv::Mat image;
-  GridMapCvConverter::toImage<float, 1>(mapIn, "layer", CV_32FC1, minValue, maxValue, image);
+  grid_map::GridMapCvConverter::toImage<float, 1>(
+    mapIn, "layer", CV_32FC1, minValue, maxValue,
+    image);
 
   // Convert back to grid map.
-  GridMap mapOut(mapIn);
+  grid_map::GridMap mapOut(mapIn);
   mapOut["layer"].setConstant(NAN);
-  GridMapCvConverter::addLayerFromImage<float, 1>(image, "layer", mapOut, minValue, maxValue);
+  grid_map::GridMapCvConverter::addLayerFromImage<float, 1>(
+    image, "layer", mapOut, minValue,
+    maxValue);
 
   // Check data.
-  const float resolution = (maxValue - minValue) / (float) std::numeric_limits<unsigned char>::max();
-  expectNear(mapIn["layer"], mapOut["layer"], resolution, "");
+  const float resolution = (maxValue - minValue) /
+    static_cast<float>(std::numeric_limits<unsigned char>::max());
+  grid_map::expectNear(mapIn["layer"], mapOut["layer"], resolution, "");
   EXPECT_TRUE((mapIn.getLength() == mapOut.getLength()).all());
   EXPECT_TRUE((mapIn.getSize() == mapOut.getSize()).all());
 }

--- a/grid_map_cv/test/test_grid_map_cv.cpp
+++ b/grid_map_cv/test/test_grid_map_cv.cpp
@@ -10,9 +10,9 @@
 #include <gtest/gtest.h>
 
 // Run all the tests that were declared with TEST()
-int main(int argc, char **argv)
+int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  srand((int)time(0));
+  srand(static_cast<int>(time(0)));
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
related to #219.

grid_map_cv package linted and ported.

This PR also includes a fix to grid_map_core/CMakeLists.txt which could be found in 48c72e0. This fix is addressing the omission of an extra cmake config file and the omission of exporting the include directories.