### PR TITLE
[ros2] grid_map_visualization port

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ jobs:
             mkdir -p $UNDERLAY_WS/src && cp $OVERLAY_WS/src/grid_map/tools/ros2_dependencies.repos \
               $UNDERLAY_WS/ros2_dependencies.repos
             cd $UNDERLAY_WS && vcs import src < ros2_dependencies.repos
-            cp $UNDERLAY_WS/src/ros-planning/navigation2/tools/ros2_dependencies.repos \
-              $UNDERLAY_WS/ros2_dependencies.repos
-            vcs import src < ros2_dependencies.repos
+            cp $UNDERLAY_WS/src/ros-planning/navigation2/tools/underlay.repos \
+              $UNDERLAY_WS/underlay.repos
+            vcs import src < underlay.repos
             rosdep install -y --ignore-src --skip-keys "slam_toolbox" --from-paths src
             colcon build --symlink-install --packages-up-to nav2_costmap_2d rcpputils rosbag2_cpp
             source $UNDERLAY_WS/install/setup.bash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,8 @@ jobs:
               $UNDERLAY_WS/underlay.repos
             vcs import src < underlay.repos
             rosdep install -y --ignore-src --skip-keys "slam_toolbox" --from-paths src
-            colcon build --symlink-install --packages-up-to nav2_costmap_2d rcpputils rosbag2_cpp
+            colcon build --symlink-install --parallel-workers 1 --packages-up-to \
+              nav2_costmap_2d rcpputils rosbag2_cpp
             source $UNDERLAY_WS/install/setup.bash
             cd $OVERLAY_WS && rosdep install -y --ignore-src --from-paths src
       - run:

--- a/grid_map_visualization/CMakeLists.txt
+++ b/grid_map_visualization/CMakeLists.txt
@@ -20,9 +20,9 @@ set(dependencies
   grid_map_msgs
   grid_map_ros
   nav_msgs
+  rclcpp
   sensor_msgs
   visualization_msgs
-  rclcpp
 )
 
 ###########
@@ -41,14 +41,14 @@ set(library_name ${PROJECT_NAME}_core)
 add_library(${library_name} SHARED
   src/GridMapVisualization.cpp
   src/GridMapVisualizationHelpers.cpp
-  src/visualizations/VisualizationBase.cpp
-  src/visualizations/VisualizationFactory.cpp
-  src/visualizations/PointCloudVisualization.cpp
   src/visualizations/FlatPointCloudVisualization.cpp
-  src/visualizations/VectorVisualization.cpp
-  src/visualizations/OccupancyGridVisualization.cpp
   src/visualizations/GridCellsVisualization.cpp
   src/visualizations/MapRegionVisualization.cpp
+  src/visualizations/OccupancyGridVisualization.cpp
+  src/visualizations/PointCloudVisualization.cpp
+  src/visualizations/VectorVisualization.cpp
+  src/visualizations/VisualizationFactory.cpp
+  src/visualizations/VisualizationBase.cpp
 )
 
 ament_target_dependencies(${library_name}

--- a/grid_map_visualization/CMakeLists.txt
+++ b/grid_map_visualization/CMakeLists.txt
@@ -1,45 +1,28 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(grid_map_visualization)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+## Find libraries
+find_package(ament_cmake REQUIRED)
+find_package(grid_map_cmake_helpers REQUIRED)
+find_package(grid_map_core REQUIRED)
+find_package(grid_map_msgs REQUIRED)
+find_package(grid_map_ros REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
+find_package(Eigen3 REQUIRED)
 
-## Find catkin macros and libraries
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  tf
+grid_map_package()
+
+set(dependencies
   grid_map_core
-  grid_map_ros
   grid_map_msgs
-  visualization_msgs
-  sensor_msgs
+  grid_map_ros
   nav_msgs
-)
-
-## System dependencies are found with CMake's conventions
-#find_package(Eigen3 REQUIRED)
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
-  INCLUDE_DIRS
-    include
-#  LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS
-    roscpp
-    tf
-    grid_map_core
-    grid_map_ros
-    grid_map_msgs
-    visualization_msgs
-    sensor_msgs
-    nav_msgs
+  sensor_msgs
+  visualization_msgs
+  rclcpp
 )
 
 ###########
@@ -47,22 +30,15 @@ catkin_package(
 ###########
 
 ## Specify additional locations of header files
-## Your package locations should be listed before other locations
 include_directories(
   include
-  ${catkin_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIR}
 )
 
-## Declare a cpp library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/grid_map_visualization_node.cpp
-# )
+set(library_name ${PROJECT_NAME}_core)
 
-## Declare a cpp executable
-add_executable(
-  ${PROJECT_NAME}
-  src/grid_map_visualization_node.cpp
+## Declare a cpp library
+add_library(${library_name} SHARED
   src/GridMapVisualization.cpp
   src/GridMapVisualizationHelpers.cpp
   src/visualizations/VisualizationBase.cpp
@@ -75,14 +51,20 @@ add_executable(
   src/visualizations/MapRegionVisualization.cpp
 )
 
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-# add_dependencies(grid_map_visualization_node grid_map_visualization_generate_messages_cpp)
+ament_target_dependencies(${library_name}
+  ${dependencies}
+)
 
-## Specify libraries to link a library or executable target against
-target_link_libraries(
-  ${PROJECT_NAME}
-  ${catkin_LIBRARIES}
+# Declare cpp node executable
+add_executable(${PROJECT_NAME}
+  src/grid_map_visualization_node.cpp
+)
+
+## Specify libraries to link executable target against
+target_link_libraries(${PROJECT_NAME} ${library_name})
+
+ament_target_dependencies(${PROJECT_NAME}
+  ${dependencies}
 )
 
 #############
@@ -90,15 +72,53 @@ target_link_libraries(
 #############
 
 # Mark executables and/or libraries for installation
-install(
-  TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+install(TARGETS ${library_name}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS ${PROJECT_NAME}
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
 # Mark other files for installation
 install(
   DIRECTORY doc
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  DESTINATION share/${PROJECT_NAME}
 )
+
+#############
+## Testing ##
+#############
+
+if(BUILD_TESTING)
+  # Linting is setup this way to add a filter
+  # to ament_cpplint to ignore the lack of
+  # copyright messages at the top of files.
+  # Copyright messages are being checked for by both
+  # ament_cmake_cpplint & ament_cmake_copyright.
+
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_lint_auto QUIET)
+  if(ament_lint_auto_FOUND)
+    # exclude copyright checks
+    list(APPEND AMENT_LINT_AUTO_EXCLUDE
+      ament_cmake_cpplint
+      ament_cmake_copyright
+    )
+    ament_lint_auto_find_test_dependencies()
+
+    # run cpplint without copyright filter
+    find_package(ament_cmake_cpplint)
+    ament_cpplint(
+      FILTERS -legal/copyright
+    )
+  endif()
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_include_directories(include)
+ament_export_libraries(${library_name})
+ament_export_dependencies(${dependencies})
+ament_package()

--- a/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
@@ -78,8 +78,8 @@ private:
    */
   void updateSubscriptionCallback();
 
-  //! ROS nodehandle.
-  rclcpp::Node::SharedPtr nodeHandle_;
+  //! ROS node.
+  rclcpp::Node::SharedPtr node_;
 
   //! Parameter name of the visualizer configuration list.
   std::string visualizationsParameter_;

--- a/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
@@ -11,19 +11,19 @@
 #define GRID_MAP_VISUALIZATION__GRIDMAPVISUALIZATION_HPP_
 
 #include <grid_map_msgs/msg/grid_map.hpp>
-#include <grid_map_visualization/visualizations/VisualizationFactory.hpp>
 #include <grid_map_visualization/visualizations/MapRegionVisualization.hpp>
+#include <grid_map_visualization/visualizations/OccupancyGridVisualization.hpp>
 #include <grid_map_visualization/visualizations/PointCloudVisualization.hpp>
 #include <grid_map_visualization/visualizations/VectorVisualization.hpp>
-#include <grid_map_visualization/visualizations/OccupancyGridVisualization.hpp>
+#include <grid_map_visualization/visualizations/VisualizationFactory.hpp>
 
 // ROS
 #include <rclcpp/rclcpp.hpp>
 
 // STD
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 namespace grid_map_visualization
 {

--- a/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
@@ -7,7 +7,8 @@
  *
  */
 
-#pragma once
+#ifndef GRID_MAP_VISUALIZATION__GRIDMAPVISUALIZATION_HPP_
+#define GRID_MAP_VISUALIZATION__GRIDMAPVISUALIZATION_HPP_
 
 #include <grid_map_msgs/GridMap.h>
 #include <grid_map_visualization/visualizations/VisualizationFactory.hpp>
@@ -20,23 +21,24 @@
 #include <ros/ros.h>
 
 // STD
+#include <string>
 #include <vector>
 #include <memory>
 
-namespace grid_map_visualization {
+namespace grid_map_visualization
+{
 
 /*!
  * Visualizes a grid map by publishing different topics that can be viewed in Rviz.
  */
 class GridMapVisualization
 {
- public:
-
+public:
   /*!
    * Constructor.
    * @param nodeHandle the ROS node handle.
    */
-  GridMapVisualization(ros::NodeHandle& nodeHandle, const std::string& parameterName);
+  GridMapVisualization(ros::NodeHandle & nodeHandle, const std::string & parameterName);
 
   /*!
    * Destructor.
@@ -47,10 +49,9 @@ class GridMapVisualization
    * Callback function for the grid map.
    * @param message the grid map message to be visualized.
    */
-  void callback(const grid_map_msgs::GridMap& message);
+  void callback(const grid_map_msgs::GridMap & message);
 
- private:
-
+private:
   /*!
    * Read parameters from ROS.
    * @return true if successful.
@@ -69,10 +70,10 @@ class GridMapVisualization
    * grid map to safe bandwidth.
    * @param timerEvent the timer event.
    */
-  void updateSubscriptionCallback(const ros::TimerEvent& timerEvent);
+  void updateSubscriptionCallback(const ros::TimerEvent & timerEvent);
 
   //! ROS nodehandle.
-  ros::NodeHandle& nodeHandle_;
+  ros::NodeHandle & nodeHandle_;
 
   //! Parameter name of the visualizer configuration list.
   std::string visualizationsParameter_;
@@ -99,4 +100,5 @@ class GridMapVisualization
   bool isSubscribed_;
 };
 
-} /* namespace */
+}  // namespace grid_map_visualization
+#endif  // GRID_MAP_VISUALIZATION__GRIDMAPVISUALIZATION_HPP_

--- a/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
@@ -31,7 +31,7 @@ namespace grid_map_visualization
 /*!
  * Visualizes a grid map by publishing different topics that can be viewed in Rviz.
  */
-class GridMapVisualization
+class GridMapVisualization : public rclcpp::Node
 {
 public:
   /*!
@@ -50,12 +50,6 @@ public:
    * @param message the grid map message to be visualized.
    */
   void callback(const grid_map_msgs::msg::GridMap::SharedPtr message);
-
-  /*!
-   * Gets pointer to rclcpp::Node.
-   * @return shared pointer to rclcpp::Node object.
-   */
-  rclcpp::Node::SharedPtr get_node_ptr();
 
 private:
   /*!
@@ -77,9 +71,6 @@ private:
    * @param timerEvent the timer event.
    */
   void updateSubscriptionCallback();
-
-  //! ROS node.
-  rclcpp::Node::SharedPtr node_;
 
   //! Parameter name of the visualizer configuration list.
   std::string visualizationsParameter_;

--- a/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
@@ -10,7 +10,7 @@
 #ifndef GRID_MAP_VISUALIZATION__GRIDMAPVISUALIZATION_HPP_
 #define GRID_MAP_VISUALIZATION__GRIDMAPVISUALIZATION_HPP_
 
-#include <grid_map_msgs/GridMap.h>
+#include <grid_map_msgs/msg/grid_map.hpp>
 #include <grid_map_visualization/visualizations/VisualizationFactory.hpp>
 #include <grid_map_visualization/visualizations/MapRegionVisualization.hpp>
 #include <grid_map_visualization/visualizations/PointCloudVisualization.hpp>
@@ -18,7 +18,7 @@
 #include <grid_map_visualization/visualizations/OccupancyGridVisualization.hpp>
 
 // ROS
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 // STD
 #include <string>
@@ -36,9 +36,9 @@ class GridMapVisualization
 public:
   /*!
    * Constructor.
-   * @param nodeHandle the ROS node handle.
+   * @param parameterName The config parameter name.
    */
-  GridMapVisualization(ros::NodeHandle & nodeHandle, const std::string & parameterName);
+  explicit GridMapVisualization(const std::string & parameterName);
 
   /*!
    * Destructor.
@@ -49,7 +49,13 @@ public:
    * Callback function for the grid map.
    * @param message the grid map message to be visualized.
    */
-  void callback(const grid_map_msgs::GridMap & message);
+  void callback(const grid_map_msgs::msg::GridMap::SharedPtr message);
+
+  /*!
+   * Gets pointer to rclcpp::Node.
+   * @return shared pointer to rclcpp::Node object.
+   */
+  rclcpp::Node::SharedPtr get_node_ptr();
 
 private:
   /*!
@@ -67,19 +73,19 @@ private:
   /*!
    * Check if visualizations are active (subscribed to),
    * and accordingly cancels/activates the subscription to the
-   * grid map to safe bandwidth.
+   * grid map to save bandwidth.
    * @param timerEvent the timer event.
    */
-  void updateSubscriptionCallback(const ros::TimerEvent & timerEvent);
+  // void updateSubscriptionCallback(const ros::TimerEvent & timerEvent);
 
   //! ROS nodehandle.
-  ros::NodeHandle & nodeHandle_;
+  rclcpp::Node::SharedPtr nodeHandle_;
 
   //! Parameter name of the visualizer configuration list.
   std::string visualizationsParameter_;
 
   //! ROS subscriber to the grid map.
-  ros::Subscriber mapSubscriber_;
+  rclcpp::Subscription<grid_map_msgs::msg::GridMap>::SharedPtr mapSubscriber_;
 
   //! Topic name of the grid map to be visualized.
   std::string mapTopic_;
@@ -88,16 +94,16 @@ private:
   std::vector<std::shared_ptr<VisualizationBase>> visualizations_;
 
   //! Visualization factory.
-  VisualizationFactory factory_;
+  std::shared_ptr<VisualizationFactory> factory_;
 
   //! Timer to check the activity of the visualizations.
-  ros::Timer activityCheckTimer_;
+  // rclcpp::TimerBase activityCheckTimer_;
 
   //! Duration of checking the activity of the visualizations.
-  ros::Duration activityCheckDuration_;
+  // rclcpp::Duration activityCheckDuration_;
 
   //! If the grid map visualization is subscribed to the grid map.
-  bool isSubscribed_;
+  // bool isSubscribed_;
 };
 
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/GridMapVisualization.hpp
@@ -76,7 +76,7 @@ private:
    * grid map to save bandwidth.
    * @param timerEvent the timer event.
    */
-  // void updateSubscriptionCallback(const ros::TimerEvent & timerEvent);
+  void updateSubscriptionCallback();
 
   //! ROS nodehandle.
   rclcpp::Node::SharedPtr nodeHandle_;
@@ -97,13 +97,13 @@ private:
   std::shared_ptr<VisualizationFactory> factory_;
 
   //! Timer to check the activity of the visualizations.
-  // rclcpp::TimerBase activityCheckTimer_;
+  rclcpp::TimerBase::SharedPtr activityCheckTimer_;
 
-  //! Duration of checking the activity of the visualizations.
-  // rclcpp::Duration activityCheckDuration_;
+  //! Rate of checking the activity of the visualizations.
+  double activityCheckRate_;
 
   //! If the grid map visualization is subscribed to the grid map.
-  // bool isSubscribed_;
+  bool isSubscribed_;
 };
 
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/include/grid_map_visualization/GridMapVisualizationHelpers.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/GridMapVisualizationHelpers.hpp
@@ -6,7 +6,8 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_VISUALIZATION__GRIDMAPVISUALIZATIONHELPERS_HPP_
+#define GRID_MAP_VISUALIZATION__GRIDMAPVISUALIZATIONHELPERS_HPP_
 
 // ROS
 #include <ros/ros.h>
@@ -16,7 +17,8 @@
 // Eigen
 #include <Eigen/Core>
 
-namespace grid_map_visualization {
+namespace grid_map_visualization
+{
 
 /*!
  * Create a color message from a color vector.
@@ -24,14 +26,19 @@ namespace grid_map_visualization {
  * @param[in] colorVector the color vector
  * @param[in] resetTransparency if transparency should be reset (to fully visible) or left at current value.
  */
-void getColorMessageFromColorVector(std_msgs::ColorRGBA& colorMessage, const Eigen::Vector3f& colorVector, bool resetTransparency = true);
+void getColorMessageFromColorVector(
+  std_msgs::ColorRGBA & colorMessage,
+  const Eigen::Vector3f & colorVector,
+  bool resetTransparency = true);
 
 /*!
  * Create a color vector from a color message.
  * @param[out] colorVector the color vector.
  * @param[in] colorMessage the color message.
  */
-void getColorVectorFromColorMessage(Eigen::Vector3f& colorVector, const std_msgs::ColorRGBA& colorMessage);
+void getColorVectorFromColorMessage(
+  Eigen::Vector3f & colorVector,
+  const std_msgs::ColorRGBA & colorMessage);
 
 /*!
  * Sets a color message from a color value.
@@ -39,7 +46,9 @@ void getColorVectorFromColorMessage(Eigen::Vector3f& colorVector, const std_msgs
  * @param[in] colorValue the color value.
  * @param[in] resetTransparency if transparency should be reset (to fully visible) or left at current value.
  */
-void setColorFromColorValue(std_msgs::ColorRGBA& color, const unsigned long& colorValue, bool resetTransparency = true);
+void setColorFromColorValue(
+  std_msgs::ColorRGBA & color, const unsigned int64 & colorValue,
+  bool resetTransparency = true);
 
 /*!
  * Set the color channel from a scalar value.
@@ -51,9 +60,11 @@ void setColorFromColorValue(std_msgs::ColorRGBA& color, const unsigned long& col
  * @param[in] colorChannelLowerValue the lower value for the color channel.
  * @param[in] colorChannelUpperValue the upper value for the color channel.
  */
-void setColorChannelFromValue(float& colorChannel, const double value, const double lowerValueBound,
-                              const double upperValueBound, const bool invert = false, const double colorChannelLowerValue = 0.0,
-                              const double colorChannelUpperValue = 1.0);
+void setColorChannelFromValue(
+  float & colorChannel, const double value, const double lowerValueBound,
+  const double upperValueBound, const bool invert = false,
+  const double colorChannelLowerValue = 0.0,
+  const double colorChannelUpperValue = 1.0);
 
 /*!
  * Sets the color to the interpolation between two colors based on a scalar value.
@@ -64,9 +75,10 @@ void setColorChannelFromValue(float& colorChannel, const double value, const dou
  * @param[in] lowerValueBound the lower boundary of the value.
  * @param[in] upperValueBound the upper boundary of the value.
  */
-void interpolateBetweenColors(std_msgs::ColorRGBA& color, const std_msgs::ColorRGBA& colorForLowerValue,
-                              const std_msgs::ColorRGBA& colorForUpperValue, const double value,
-                              const double lowerValueBound, const double upperValueBound);
+void interpolateBetweenColors(
+  std_msgs::ColorRGBA & color, const std_msgs::ColorRGBA & colorForLowerValue,
+  const std_msgs::ColorRGBA & colorForUpperValue, const double value,
+  const double lowerValueBound, const double upperValueBound);
 
 /*!
  * Sets the saturation of the color from a scalar value.
@@ -77,8 +89,9 @@ void interpolateBetweenColors(std_msgs::ColorRGBA& color, const std_msgs::ColorR
  * @param[in] maxSaturation the maximum saturation.
  * @param[in] minSaturation the minimum saturation.
  */
-void setSaturationFromValue(std_msgs::ColorRGBA& color, const double value, const double lowerValueBound,
-                            const double upperValueBound, const double maxSaturation, const double minSaturation);
+void setSaturationFromValue(
+  std_msgs::ColorRGBA & color, const double value, const double lowerValueBound,
+  const double upperValueBound, const double maxSaturation, const double minSaturation);
 
 /*!
  * Set the color from the rainbow color spectrum based on scalar value.
@@ -87,8 +100,9 @@ void setSaturationFromValue(std_msgs::ColorRGBA& color, const double value, cons
  * @param[in] lowerValueBound the lower boundary of the value.
  * @param[in] upperValueBound the upper boundary of the value.
  */
-void setColorFromValue(std_msgs::ColorRGBA& color, const double value, const double lowerValueBound,
-                       const double upperValueBound);
+void setColorFromValue(
+  std_msgs::ColorRGBA & color, const double value, const double lowerValueBound,
+  const double upperValueBound);
 
 /*!
  * Computes a linear mapping for a query from the source and to the map.
@@ -100,7 +114,8 @@ void setColorFromValue(std_msgs::ColorRGBA& color, const double value, const dou
  * @return the query mapped to the map.
  */
 double computeLinearMapping(
-    const double& sourceValue, const double& sourceLowerValue, const double& sourceUpperValue,
-    const double& mapLowerValue, const double& mapUpperValue);
+  const double & sourceValue, const double & sourceLowerValue, const double & sourceUpperValue,
+  const double & mapLowerValue, const double & mapUpperValue);
 
-} /* namespace */
+}  // namespace grid_map_visualization
+#endif  // GRID_MAP_VISUALIZATION__GRIDMAPVISUALIZATIONHELPERS_HPP_

--- a/grid_map_visualization/include/grid_map_visualization/GridMapVisualizationHelpers.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/GridMapVisualizationHelpers.hpp
@@ -10,9 +10,9 @@
 #define GRID_MAP_VISUALIZATION__GRIDMAPVISUALIZATIONHELPERS_HPP_
 
 // ROS
-#include <ros/ros.h>
-#include <visualization_msgs/MarkerArray.h>
-#include <std_msgs/ColorRGBA.h>
+#include <rclcpp/rclcpp.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+#include <std_msgs/msg/color_rgba.hpp>
 
 // Eigen
 #include <Eigen/Core>
@@ -27,7 +27,7 @@ namespace grid_map_visualization
  * @param[in] resetTransparency if transparency should be reset (to fully visible) or left at current value.
  */
 void getColorMessageFromColorVector(
-  std_msgs::ColorRGBA & colorMessage,
+  std_msgs::msg::ColorRGBA & colorMessage,
   const Eigen::Vector3f & colorVector,
   bool resetTransparency = true);
 
@@ -38,7 +38,7 @@ void getColorMessageFromColorVector(
  */
 void getColorVectorFromColorMessage(
   Eigen::Vector3f & colorVector,
-  const std_msgs::ColorRGBA & colorMessage);
+  const std_msgs::msg::ColorRGBA & colorMessage);
 
 /*!
  * Sets a color message from a color value.
@@ -47,7 +47,7 @@ void getColorVectorFromColorMessage(
  * @param[in] resetTransparency if transparency should be reset (to fully visible) or left at current value.
  */
 void setColorFromColorValue(
-  std_msgs::ColorRGBA & color, const unsigned int64 & colorValue,
+  std_msgs::msg::ColorRGBA & color, const uint64_t & colorValue,
   bool resetTransparency = true);
 
 /*!
@@ -76,8 +76,8 @@ void setColorChannelFromValue(
  * @param[in] upperValueBound the upper boundary of the value.
  */
 void interpolateBetweenColors(
-  std_msgs::ColorRGBA & color, const std_msgs::ColorRGBA & colorForLowerValue,
-  const std_msgs::ColorRGBA & colorForUpperValue, const double value,
+  std_msgs::msg::ColorRGBA & color, const std_msgs::msg::ColorRGBA & colorForLowerValue,
+  const std_msgs::msg::ColorRGBA & colorForUpperValue, const double value,
   const double lowerValueBound, const double upperValueBound);
 
 /*!
@@ -90,7 +90,7 @@ void interpolateBetweenColors(
  * @param[in] minSaturation the minimum saturation.
  */
 void setSaturationFromValue(
-  std_msgs::ColorRGBA & color, const double value, const double lowerValueBound,
+  std_msgs::msg::ColorRGBA & color, const double value, const double lowerValueBound,
   const double upperValueBound, const double maxSaturation, const double minSaturation);
 
 /*!
@@ -101,7 +101,7 @@ void setSaturationFromValue(
  * @param[in] upperValueBound the upper boundary of the value.
  */
 void setColorFromValue(
-  std_msgs::ColorRGBA & color, const double value, const double lowerValueBound,
+  std_msgs::msg::ColorRGBA & color, const double value, const double lowerValueBound,
   const double upperValueBound);
 
 /*!

--- a/grid_map_visualization/include/grid_map_visualization/GridMapVisualizationHelpers.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/GridMapVisualizationHelpers.hpp
@@ -11,8 +11,8 @@
 
 // ROS
 #include <rclcpp/rclcpp.hpp>
-#include <visualization_msgs/msg/marker_array.hpp>
 #include <std_msgs/msg/color_rgba.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 // Eigen
 #include <Eigen/Core>

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp
@@ -6,7 +6,8 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__FLATPOINTCLOUDVISUALIZATION_HPP_
+#define GRID_MAP_VISUALIZATION__VISUALIZATIONS__FLATPOINTCLOUDVISUALIZATION_HPP_
 
 #include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
@@ -14,21 +15,23 @@
 // ROS
 #include <ros/ros.h>
 
-namespace grid_map_visualization {
+#include <string>
+
+namespace grid_map_visualization
+{
 
 /*!
  * Visualization of the grid map as a flat point cloud.
  */
 class FlatPointCloudVisualization : public VisualizationBase
 {
- public:
-
+public:
   /*!
    * Constructor.
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  FlatPointCloudVisualization(ros::NodeHandle& nodeHandle, const std::string& name);
+  FlatPointCloudVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -40,7 +43,7 @@ class FlatPointCloudVisualization : public VisualizationBase
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue& config);
+  bool readParameters(XmlRpc::XmlRpcValue & config);
 
   /*!
    * Initialization.
@@ -52,9 +55,9 @@ class FlatPointCloudVisualization : public VisualizationBase
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap& map);
+  bool visualize(const grid_map::GridMap & map);
 
- private:
+private:
   //! Type that is transformed to points.
   std::string layer_;
 
@@ -62,4 +65,5 @@ class FlatPointCloudVisualization : public VisualizationBase
   double height_;
 };
 
-} /* namespace */
+}  // namespace grid_map_visualization
+#endif  // GRID_MAP_VISUALIZATION__VISUALIZATIONS__FLATPOINTCLOUDVISUALIZATION_HPP_

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp
@@ -29,10 +29,9 @@ class FlatPointCloudVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  FlatPointCloudVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
+  explicit FlatPointCloudVisualization(const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp
@@ -12,7 +12,7 @@
 #include <grid_map_core/GridMap.hpp>
 
 // ROS
-// #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <string>
 

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp
@@ -29,10 +29,10 @@ class FlatPointCloudVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param nodeHandle the ROS node handle.
+   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  FlatPointCloudVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
+  FlatPointCloudVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp
@@ -9,13 +9,14 @@
 #ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__FLATPOINTCLOUDVISUALIZATION_HPP_
 #define GRID_MAP_VISUALIZATION__VISUALIZATIONS__FLATPOINTCLOUDVISUALIZATION_HPP_
 
-#include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
 
 // ROS
-#include <ros/ros.h>
+// #include <rclcpp/rclcpp.hpp>
 
 #include <string>
+
+#include "grid_map_visualization/visualizations/VisualizationBase.hpp"
 
 namespace grid_map_visualization
 {
@@ -31,7 +32,7 @@ public:
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  FlatPointCloudVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
+  FlatPointCloudVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -43,19 +44,19 @@ public:
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue & config);
+  bool readParameters() override;
 
   /*!
    * Initialization.
    */
-  bool initialize();
+  bool initialize() override;
 
   /*!
    * Generates the visualization.
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap & map);
+  bool visualize(const grid_map::GridMap & map) override;
 
 private:
   //! Type that is transformed to points.
@@ -63,6 +64,9 @@ private:
 
   //! Height of the z-coordinate at which the flat point cloud is visualized.
   double height_;
+
+  //! ROS publisher.
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr publisher_;
 };
 
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/GridCellsVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/GridCellsVisualization.hpp
@@ -28,10 +28,10 @@ class GridCellsVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param nodeHandle the ROS node handle.
+   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  GridCellsVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
+  GridCellsVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/GridCellsVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/GridCellsVisualization.hpp
@@ -6,7 +6,8 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__GRIDCELLSVISUALIZATION_HPP_
+#define GRID_MAP_VISUALIZATION__VISUALIZATIONS__GRIDCELLSVISUALIZATION_HPP_
 
 #include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
@@ -14,18 +15,20 @@
 // ROS
 #include <ros/ros.h>
 
-namespace grid_map_visualization {
+#include <string>
+
+namespace grid_map_visualization
+{
 
 class GridCellsVisualization : public VisualizationBase
 {
- public:
-
+public:
   /*!
    * Constructor.
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  GridCellsVisualization(ros::NodeHandle& nodeHandle, const std::string& name);
+  GridCellsVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -37,7 +40,7 @@ class GridCellsVisualization : public VisualizationBase
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue& config);
+  bool readParameters(XmlRpc::XmlRpcValue & config);
 
   /*!
    * Initialization.
@@ -49,10 +52,9 @@ class GridCellsVisualization : public VisualizationBase
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap& map);
+  bool visualize(const grid_map::GridMap & map);
 
- private:
-
+private:
   //! Type that is transformed to the occupancy grid.
   std::string layer_;
 
@@ -60,4 +62,5 @@ class GridCellsVisualization : public VisualizationBase
   float lowerThreshold_, upperThreshold_;
 };
 
-} /* namespace */
+}  // namespace grid_map_visualization
+#endif  // GRID_MAP_VISUALIZATION__VISUALIZATIONS__GRIDCELLSVISUALIZATION_HPP_

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/GridCellsVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/GridCellsVisualization.hpp
@@ -28,10 +28,9 @@ class GridCellsVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  GridCellsVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
+  explicit GridCellsVisualization(const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/GridCellsVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/GridCellsVisualization.hpp
@@ -9,13 +9,16 @@
 #ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__GRIDCELLSVISUALIZATION_HPP_
 #define GRID_MAP_VISUALIZATION__VISUALIZATIONS__GRIDCELLSVISUALIZATION_HPP_
 
-#include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
+#include <nav_msgs/msg/grid_cells.hpp>
 
 // ROS
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <string>
+
+#include "grid_map_visualization/visualizations/VisualizationBase.hpp"
+
 
 namespace grid_map_visualization
 {
@@ -28,7 +31,7 @@ public:
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  GridCellsVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
+  GridCellsVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -40,19 +43,19 @@ public:
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue & config);
+  bool readParameters() override;
 
   /*!
    * Initialization.
    */
-  bool initialize();
+  bool initialize() override;
 
   /*!
    * Generates the visualization.
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap & map);
+  bool visualize(const grid_map::GridMap & map) override;
 
 private:
   //! Type that is transformed to the occupancy grid.
@@ -60,6 +63,9 @@ private:
 
   //! Values that are between lower and upper threshold are shown.
   float lowerThreshold_, upperThreshold_;
+
+  //! ROS publisher.
+  rclcpp::Publisher<nav_msgs::msg::GridCells>::SharedPtr publisher_;
 };
 
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/MapRegionVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/MapRegionVisualization.hpp
@@ -31,10 +31,10 @@ class MapRegionVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param nodeHandle the ROS node handle.
+   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  MapRegionVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
+  MapRegionVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/MapRegionVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/MapRegionVisualization.hpp
@@ -6,7 +6,8 @@
  *	 Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__MAPREGIONVISUALIZATION_HPP_
+#define GRID_MAP_VISUALIZATION__VISUALIZATIONS__MAPREGIONVISUALIZATION_HPP_
 
 #include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
@@ -16,21 +17,23 @@
 #include <visualization_msgs/Marker.h>
 #include <std_msgs/ColorRGBA.h>
 
-namespace grid_map_visualization {
+#include <string>
+
+namespace grid_map_visualization
+{
 
 /*!
  * Visualization of the region of the grid map as border line.
  */
 class MapRegionVisualization : public VisualizationBase
 {
- public:
-
+public:
   /*!
    * Constructor.
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  MapRegionVisualization(ros::NodeHandle& nodeHandle, const std::string& name);
+  MapRegionVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -42,7 +45,7 @@ class MapRegionVisualization : public VisualizationBase
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue& config);
+  bool readParameters(XmlRpc::XmlRpcValue & config);
 
   /*!
    * Initialization.
@@ -54,10 +57,9 @@ class MapRegionVisualization : public VisualizationBase
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap& map);
+  bool visualize(const grid_map::GridMap & map);
 
- private:
-
+private:
   //! Marker to be published.
   visualization_msgs::Marker marker_;
 
@@ -69,7 +71,7 @@ class MapRegionVisualization : public VisualizationBase
 
   //! Line width of the map region marker [m].
   double lineWidth_;
-
 };
 
-} /* namespace */
+}  // namespace grid_map_visualization
+#endif  // GRID_MAP_VISUALIZATION__VISUALIZATIONS__MAPREGIONVISUALIZATION_HPP_

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/MapRegionVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/MapRegionVisualization.hpp
@@ -31,10 +31,9 @@ class MapRegionVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  MapRegionVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
+  explicit MapRegionVisualization(const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/MapRegionVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/MapRegionVisualization.hpp
@@ -9,15 +9,16 @@
 #ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__MAPREGIONVISUALIZATION_HPP_
 #define GRID_MAP_VISUALIZATION__VISUALIZATIONS__MAPREGIONVISUALIZATION_HPP_
 
-#include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
 
 // ROS
-#include <ros/ros.h>
-#include <visualization_msgs/Marker.h>
-#include <std_msgs/ColorRGBA.h>
+#include <rclcpp/rclcpp.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+#include <std_msgs/msg/color_rgba.hpp>
 
 #include <string>
+
+#include "grid_map_visualization/visualizations/VisualizationBase.hpp"
 
 namespace grid_map_visualization
 {
@@ -33,7 +34,7 @@ public:
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  MapRegionVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
+  MapRegionVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -45,32 +46,35 @@ public:
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue & config);
+  bool readParameters() override;
 
   /*!
    * Initialization.
    */
-  bool initialize();
+  bool initialize() override;
 
   /*!
    * Generates the visualization.
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap & map);
+  bool visualize(const grid_map::GridMap & map) override;
 
 private:
   //! Marker to be published.
-  visualization_msgs::Marker marker_;
+  visualization_msgs::msg::Marker marker_;
 
   //! Number of vertices of the map region visualization.
   const unsigned int nVertices_;
 
   //! Color of the map region visualization.
-  std_msgs::ColorRGBA color_;
+  std_msgs::msg::ColorRGBA color_;
 
   //! Line width of the map region marker [m].
   double lineWidth_;
+
+  //! ROS publisher.
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr publisher_;
 };
 
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/MapRegionVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/MapRegionVisualization.hpp
@@ -13,8 +13,8 @@
 
 // ROS
 #include <rclcpp/rclcpp.hpp>
-#include <visualization_msgs/msg/marker.hpp>
 #include <std_msgs/msg/color_rgba.hpp>
+#include <visualization_msgs/msg/marker.hpp>
 
 #include <string>
 

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/OccupancyGridVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/OccupancyGridVisualization.hpp
@@ -9,13 +9,12 @@
 #ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__OCCUPANCYGRIDVISUALIZATION_HPP_
 #define GRID_MAP_VISUALIZATION__VISUALIZATIONS__OCCUPANCYGRIDVISUALIZATION_HPP_
 
-#include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
-
-// ROS
-#include <ros/ros.h>
+#include <nav_msgs/msg/occupancy_grid.hpp>
 
 #include <string>
+
+#include "grid_map_visualization/visualizations/VisualizationBase.hpp"
 
 namespace grid_map_visualization
 {
@@ -28,7 +27,7 @@ public:
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  OccupancyGridVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
+  OccupancyGridVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -40,19 +39,19 @@ public:
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue & config);
+  bool readParameters() override;
 
   /*!
    * Initialization.
    */
-  bool initialize();
+  bool initialize() override;
 
   /*!
    * Generates the visualization.
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap & map);
+  bool visualize(const grid_map::GridMap & map) override;
 
 private:
   //! Type that is transformed to the occupancy grid.
@@ -61,6 +60,9 @@ private:
   //! Minimum and maximum value of the grid map data
   // (used to normalize the cell data in [min, max]).
   float dataMin_, dataMax_;
+
+  //! ROS publisher.
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr publisher_;
 };
 
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/OccupancyGridVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/OccupancyGridVisualization.hpp
@@ -6,7 +6,8 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__OCCUPANCYGRIDVISUALIZATION_HPP_
+#define GRID_MAP_VISUALIZATION__VISUALIZATIONS__OCCUPANCYGRIDVISUALIZATION_HPP_
 
 #include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
@@ -14,18 +15,20 @@
 // ROS
 #include <ros/ros.h>
 
-namespace grid_map_visualization {
+#include <string>
+
+namespace grid_map_visualization
+{
 
 class OccupancyGridVisualization : public VisualizationBase
 {
- public:
-
+public:
   /*!
    * Constructor.
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  OccupancyGridVisualization(ros::NodeHandle& nodeHandle, const std::string& name);
+  OccupancyGridVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -37,7 +40,7 @@ class OccupancyGridVisualization : public VisualizationBase
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue& config);
+  bool readParameters(XmlRpc::XmlRpcValue & config);
 
   /*!
    * Initialization.
@@ -49,15 +52,16 @@ class OccupancyGridVisualization : public VisualizationBase
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap& map);
+  bool visualize(const grid_map::GridMap & map);
 
- private:
-
+private:
   //! Type that is transformed to the occupancy grid.
   std::string layer_;
 
-  //! Minimum and maximum value of the grid map data (used to normalize the cell data in [min, max]).
+  //! Minimum and maximum value of the grid map data
+  // (used to normalize the cell data in [min, max]).
   float dataMin_, dataMax_;
 };
 
-} /* namespace */
+}  // namespace grid_map_visualization
+#endif  // GRID_MAP_VISUALIZATION__VISUALIZATIONS__OCCUPANCYGRIDVISUALIZATION_HPP_

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/OccupancyGridVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/OccupancyGridVisualization.hpp
@@ -24,10 +24,9 @@ class OccupancyGridVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  OccupancyGridVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
+  explicit OccupancyGridVisualization(const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/OccupancyGridVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/OccupancyGridVisualization.hpp
@@ -24,10 +24,10 @@ class OccupancyGridVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param nodeHandle the ROS node handle.
+   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  OccupancyGridVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
+  OccupancyGridVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/PointCloudVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/PointCloudVisualization.hpp
@@ -30,10 +30,10 @@ class PointCloudVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param nodeHandle the ROS node handle.
+   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  PointCloudVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
+  PointCloudVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/PointCloudVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/PointCloudVisualization.hpp
@@ -9,13 +9,15 @@
 #ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__POINTCLOUDVISUALIZATION_HPP_
 #define GRID_MAP_VISUALIZATION__VISUALIZATIONS__POINTCLOUDVISUALIZATION_HPP_
 
-#include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 // ROS
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <string>
+
+#include "grid_map_visualization/visualizations/VisualizationBase.hpp"
 
 namespace grid_map_visualization
 {
@@ -31,7 +33,7 @@ public:
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  PointCloudVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
+  PointCloudVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -43,23 +45,26 @@ public:
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue & config);
+  bool readParameters() override;
 
   /*!
    * Initialization.
    */
-  bool initialize();
+  bool initialize() override;
 
   /*!
    * Generates the visualization.
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap & map);
+  bool visualize(const grid_map::GridMap & map) override;
 
 private:
   //! Type that is transformed to points.
   std::string layer_;
+
+  //! ROS publisher.
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr publisher_;
 };
 
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/PointCloudVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/PointCloudVisualization.hpp
@@ -6,7 +6,8 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__POINTCLOUDVISUALIZATION_HPP_
+#define GRID_MAP_VISUALIZATION__VISUALIZATIONS__POINTCLOUDVISUALIZATION_HPP_
 
 #include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
@@ -14,21 +15,23 @@
 // ROS
 #include <ros/ros.h>
 
-namespace grid_map_visualization {
+#include <string>
+
+namespace grid_map_visualization
+{
 
 /*!
  * Visualization of the grid map as a point cloud.
  */
 class PointCloudVisualization : public VisualizationBase
 {
- public:
-
+public:
   /*!
    * Constructor.
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  PointCloudVisualization(ros::NodeHandle& nodeHandle, const std::string& name);
+  PointCloudVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -40,7 +43,7 @@ class PointCloudVisualization : public VisualizationBase
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue& config);
+  bool readParameters(XmlRpc::XmlRpcValue & config);
 
   /*!
    * Initialization.
@@ -52,11 +55,12 @@ class PointCloudVisualization : public VisualizationBase
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap& map);
+  bool visualize(const grid_map::GridMap & map);
 
- private:
+private:
   //! Type that is transformed to points.
   std::string layer_;
 };
 
-} /* namespace */
+}  // namespace grid_map_visualization
+#endif  // GRID_MAP_VISUALIZATION__VISUALIZATIONS__POINTCLOUDVISUALIZATION_HPP_

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/PointCloudVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/PointCloudVisualization.hpp
@@ -30,10 +30,9 @@ class PointCloudVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  PointCloudVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
+  explicit PointCloudVisualization(const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VectorVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VectorVisualization.hpp
@@ -33,10 +33,9 @@ class VectorVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  VectorVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
+  explicit VectorVisualization(const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VectorVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VectorVisualization.hpp
@@ -9,17 +9,18 @@
 #ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__VECTORVISUALIZATION_HPP_
 #define GRID_MAP_VISUALIZATION__VISUALIZATIONS__VECTORVISUALIZATION_HPP_
 
-#include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
 
 // ROS
-#include <ros/ros.h>
-#include <visualization_msgs/Marker.h>
-#include <std_msgs/ColorRGBA.h>
+#include <rclcpp/rclcpp.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+#include <std_msgs/msg/color_rgba.hpp>
 
 // STD
 #include <string>
 #include <vector>
+
+#include "grid_map_visualization/visualizations/VisualizationBase.hpp"
 
 namespace grid_map_visualization
 {
@@ -35,7 +36,7 @@ public:
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  VectorVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
+  VectorVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -47,23 +48,23 @@ public:
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue & config);
+  bool readParameters() override;
 
   /*!
    * Initialization.
    */
-  bool initialize();
+  bool initialize() override;
 
   /*!
    * Generates the visualization.
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap & map);
+  bool visualize(const grid_map::GridMap & map) override;
 
 private:
   //! Marker to be published.
-  visualization_msgs::Marker marker_;
+  visualization_msgs::msg::Marker marker_;
 
   //! Types that are transformed to vectors.
   std::vector<std::string> types_;
@@ -78,7 +79,10 @@ private:
   double lineWidth_;
 
   //! Color of the vectors.
-  std_msgs::ColorRGBA color_;
+  std_msgs::msg::ColorRGBA color_;
+
+  //! ROS publisher.
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr publisher_;
 };
 
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VectorVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VectorVisualization.hpp
@@ -33,10 +33,10 @@ class VectorVisualization : public VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param nodeHandle the ROS node handle.
+   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  VectorVisualization(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
+  VectorVisualization(rclcpp::Node::SharedPtr node, const std::string & name);
 
   /*!
    * Destructor.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VectorVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VectorVisualization.hpp
@@ -6,7 +6,8 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__VECTORVISUALIZATION_HPP_
+#define GRID_MAP_VISUALIZATION__VISUALIZATIONS__VECTORVISUALIZATION_HPP_
 
 #include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <grid_map_core/GridMap.hpp>
@@ -17,23 +18,24 @@
 #include <std_msgs/ColorRGBA.h>
 
 // STD
+#include <string>
 #include <vector>
 
-namespace grid_map_visualization {
+namespace grid_map_visualization
+{
 
 /*!
  * Visualization a combination of three layers of the grid map as a vector field.
  */
 class VectorVisualization : public VisualizationBase
 {
- public:
-
+public:
   /*!
    * Constructor.
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  VectorVisualization(ros::NodeHandle& nodeHandle, const std::string& name);
+  VectorVisualization(ros::NodeHandle & nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -45,7 +47,7 @@ class VectorVisualization : public VisualizationBase
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  bool readParameters(XmlRpc::XmlRpcValue& config);
+  bool readParameters(XmlRpc::XmlRpcValue & config);
 
   /*!
    * Initialization.
@@ -57,10 +59,9 @@ class VectorVisualization : public VisualizationBase
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  bool visualize(const grid_map::GridMap& map);
+  bool visualize(const grid_map::GridMap & map);
 
- private:
-
+private:
   //! Marker to be published.
   visualization_msgs::Marker marker_;
 
@@ -80,4 +81,5 @@ class VectorVisualization : public VisualizationBase
   std_msgs::ColorRGBA color_;
 };
 
-} /* namespace */
+}  // namespace grid_map_visualization
+#endif  // GRID_MAP_VISUALIZATION__VISUALIZATIONS__VECTORVISUALIZATION_HPP_

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
@@ -6,27 +6,32 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__VISUALIZATIONBASE_HPP_
+#define GRID_MAP_VISUALIZATION__VISUALIZATIONS__VISUALIZATIONBASE_HPP_
+
 
 #include <grid_map_core/GridMap.hpp>
 
 // ROS
 #include <ros/ros.h>
 
-namespace grid_map_visualization {
+#include <map>
+#include <string>
+
+namespace grid_map_visualization
+{
 
 typedef std::map<std::string, XmlRpc::XmlRpcValue> StringMap;
 
 class VisualizationBase
 {
- public:
-
+public:
   /*!
    * Constructor.
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  VisualizationBase(ros::NodeHandle& nodeHandle, const std::string& name);
+  VisualizationBase(ros::NodeHandle & nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -38,7 +43,7 @@ class VisualizationBase
    * @param config the parameters as XML.
    * @return true if successful.
    */
-  virtual bool readParameters(XmlRpc::XmlRpcValue& config);
+  virtual bool readParameters(XmlRpc::XmlRpcValue & config);
 
   /*!
    * Initialization.
@@ -50,7 +55,7 @@ class VisualizationBase
    * @param map the grid map to visualize.
    * @return true if successful.
    */
-  virtual bool visualize(const grid_map::GridMap& map) = 0;
+  virtual bool visualize(const grid_map::GridMap & map) = 0;
 
   /*!
    * Checks if visualization is active (if somebody has actually subscribed).
@@ -58,15 +63,14 @@ class VisualizationBase
    */
   bool isActive() const;
 
- protected:
-
+protected:
   /*!
    * Get a visualization parameter as a string.
    * @param[in] name the name of the parameter
    * @param[out] value the string to set with the value.
    * @return true if parameter was found, false otherwise.
    */
-  bool getParam(const std::string& name, std::string& value);
+  bool getParam(const std::string & name, std::string & value);
 
   /*!
    * Get a visualization parameter as a double.
@@ -74,7 +78,7 @@ class VisualizationBase
    * @param[out] value the double to set with the value.
    * @return true if parameter was found, false otherwise.
    */
-  bool getParam(const std::string& name, double& value);
+  bool getParam(const std::string & name, double & value);
 
   /*!
    * Get a visualization parameter as a float.
@@ -82,7 +86,7 @@ class VisualizationBase
    * @param[out] value the float to set with the value.
    * @return true if parameter was found, false otherwise.
    */
-  bool getParam(const std::string& name, float& value);
+  bool getParam(const std::string & name, float & value);
 
   /*!
    * Get a visualization parameter as an integer.
@@ -90,7 +94,7 @@ class VisualizationBase
    * @param[out] value the int to set with the value.
    * @return true if parameter was found, false otherwise.
    */
-  bool getParam(const std::string&name, int& value);
+  bool getParam(const std::string & name, int & value);
 
   /*!
    * Get a visualization parameter as a boolean.
@@ -98,10 +102,10 @@ class VisualizationBase
    * @param[out] value the boolean to set with the value.
    * @return true if parameter was found, false otherwise.
    */
-  bool getParam(const std::string& name, bool& value);
+  bool getParam(const std::string & name, bool & value);
 
   //! ROS nodehandle.
-  ros::NodeHandle& nodeHandle_;
+  ros::NodeHandle & nodeHandle_;
 
   //! Name of the visualization.
   std::string name_;
@@ -113,4 +117,5 @@ class VisualizationBase
   ros::Publisher publisher_;
 };
 
-} /* namespace */
+}  // namespace grid_map_visualization
+#endif  // GRID_MAP_VISUALIZATION__VISUALIZATIONS__VISUALIZATIONBASE_HPP_

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
@@ -13,15 +13,13 @@
 #include <grid_map_core/GridMap.hpp>
 
 // ROS
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <map>
 #include <string>
 
 namespace grid_map_visualization
 {
-
-typedef std::map<std::string, XmlRpc::XmlRpcValue> StringMap;
 
 class VisualizationBase
 {
@@ -31,7 +29,7 @@ public:
    * @param nodeHandle the ROS node handle.
    * @param name the name of the visualization.
    */
-  VisualizationBase(ros::NodeHandle & nodeHandle, const std::string & name);
+  VisualizationBase(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
 
   /*!
    * Destructor.
@@ -40,10 +38,9 @@ public:
 
   /*!
    * Read parameters from ROS.
-   * @param config the parameters as XML.
    * @return true if successful.
    */
-  virtual bool readParameters(XmlRpc::XmlRpcValue & config);
+  virtual bool readParameters() = 0;
 
   /*!
    * Initialization.
@@ -61,60 +58,14 @@ public:
    * Checks if visualization is active (if somebody has actually subscribed).
    * @return true if active, false otherwise.
    */
-  bool isActive() const;
+  bool isActive(const std::string & topic) const;
 
 protected:
-  /*!
-   * Get a visualization parameter as a string.
-   * @param[in] name the name of the parameter
-   * @param[out] value the string to set with the value.
-   * @return true if parameter was found, false otherwise.
-   */
-  bool getParam(const std::string & name, std::string & value);
-
-  /*!
-   * Get a visualization parameter as a double.
-   * @param[in] name the name of the parameter
-   * @param[out] value the double to set with the value.
-   * @return true if parameter was found, false otherwise.
-   */
-  bool getParam(const std::string & name, double & value);
-
-  /*!
-   * Get a visualization parameter as a float.
-   * @param[in] name the name of the parameter
-   * @param[out] value the float to set with the value.
-   * @return true if parameter was found, false otherwise.
-   */
-  bool getParam(const std::string & name, float & value);
-
-  /*!
-   * Get a visualization parameter as an integer.
-   * @param[in] name the name of the parameter
-   * @param[out] value the int to set with the value.
-   * @return true if parameter was found, false otherwise.
-   */
-  bool getParam(const std::string & name, int & value);
-
-  /*!
-   * Get a visualization parameter as a boolean.
-   * @param[in] name the name of the parameter
-   * @param[out] value the boolean to set with the value.
-   * @return true if parameter was found, false otherwise.
-   */
-  bool getParam(const std::string & name, bool & value);
-
   //! ROS nodehandle.
-  ros::NodeHandle & nodeHandle_;
+  rclcpp::Node::SharedPtr nodeHandle_;
 
   //! Name of the visualization.
   std::string name_;
-
-  //! Storage of the parsed XML parameters.
-  StringMap parameters_;
-
-  //! ROS publisher of the occupancy grid.
-  ros::Publisher publisher_;
 };
 
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
@@ -21,15 +21,14 @@
 namespace grid_map_visualization
 {
 
-class VisualizationBase
+class VisualizationBase : public rclcpp::Node
 {
 public:
   /*!
    * Constructor.
-   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  VisualizationBase(rclcpp::Node::SharedPtr node, const std::string & name);
+  explicit VisualizationBase(const std::string & name);
 
   /*!
    * Destructor.
@@ -59,13 +58,6 @@ public:
    * @return true if active, false otherwise.
    */
   bool isActive() const;
-
-protected:
-  //! ROS node.
-  rclcpp::Node::SharedPtr node_;
-
-  //! Name of the visualization.
-  std::string name_;
 };
 
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
@@ -26,10 +26,10 @@ class VisualizationBase
 public:
   /*!
    * Constructor.
-   * @param nodeHandle the ROS node handle.
+   * @param node the ROS node.
    * @param name the name of the visualization.
    */
-  VisualizationBase(rclcpp::Node::SharedPtr nodeHandle, const std::string & name);
+  VisualizationBase(rclcpp::Node::SharedPtr node, const std::string & name);
 
   /*!
    * Destructor.
@@ -61,8 +61,8 @@ public:
   bool isActive() const;
 
 protected:
-  //! ROS nodehandle.
-  rclcpp::Node::SharedPtr nodeHandle_;
+  //! ROS node.
+  rclcpp::Node::SharedPtr node_;
 
   //! Name of the visualization.
   std::string name_;

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
@@ -58,7 +58,7 @@ public:
    * Checks if visualization is active (if somebody has actually subscribed).
    * @return true if active, false otherwise.
    */
-  bool isActive(const std::string & topic) const;
+  bool isActive() const;
 
 protected:
   //! ROS nodehandle.

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationFactory.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationFactory.hpp
@@ -9,9 +9,9 @@
 #ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__VISUALIZATIONFACTORY_HPP_
 #define GRID_MAP_VISUALIZATION__VISUALIZATIONS__VISUALIZATIONFACTORY_HPP_
 
-#include <vector>
-#include <string>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "grid_map_visualization/visualizations/VisualizationBase.hpp"
 

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationFactory.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationFactory.hpp
@@ -9,10 +9,11 @@
 #ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__VISUALIZATIONFACTORY_HPP_
 #define GRID_MAP_VISUALIZATION__VISUALIZATIONS__VISUALIZATIONFACTORY_HPP_
 
-#include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <vector>
 #include <string>
 #include <memory>
+
+#include "grid_map_visualization/visualizations/VisualizationBase.hpp"
 
 namespace grid_map_visualization
 {
@@ -20,16 +21,17 @@ namespace grid_map_visualization
 class VisualizationFactory
 {
 public:
-  explicit VisualizationFactory(ros::NodeHandle & nodeHandle);
+  explicit VisualizationFactory(rclcpp::Node::SharedPtr nodeHandle);
   virtual ~VisualizationFactory();
 
   bool isValidType(const std::string & type);
+
   std::shared_ptr<VisualizationBase> getInstance(
     const std::string & type,
     const std::string & name);
 
 private:
-  ros::NodeHandle & nodeHandle_;
+  rclcpp::Node::SharedPtr nodeHandle_;
   std::vector<std::string> types_;
 };
 

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationFactory.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationFactory.hpp
@@ -21,7 +21,7 @@ namespace grid_map_visualization
 class VisualizationFactory
 {
 public:
-  explicit VisualizationFactory(rclcpp::Node::SharedPtr nodeHandle);
+  explicit VisualizationFactory(rclcpp::Node::SharedPtr node);
   virtual ~VisualizationFactory();
 
   bool isValidType(const std::string & type);
@@ -31,7 +31,7 @@ public:
     const std::string & name);
 
 private:
-  rclcpp::Node::SharedPtr nodeHandle_;
+  rclcpp::Node::SharedPtr node_;
   std::vector<std::string> types_;
 };
 

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationFactory.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationFactory.hpp
@@ -6,27 +6,32 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#pragma once
+#ifndef GRID_MAP_VISUALIZATION__VISUALIZATIONS__VISUALIZATIONFACTORY_HPP_
+#define GRID_MAP_VISUALIZATION__VISUALIZATIONS__VISUALIZATIONFACTORY_HPP_
 
 #include <grid_map_visualization/visualizations/VisualizationBase.hpp>
 #include <vector>
 #include <string>
 #include <memory>
 
-namespace grid_map_visualization {
+namespace grid_map_visualization
+{
 
 class VisualizationFactory
 {
- public:
-  VisualizationFactory(ros::NodeHandle& nodeHandle);
+public:
+  explicit VisualizationFactory(ros::NodeHandle & nodeHandle);
   virtual ~VisualizationFactory();
 
-  bool isValidType(const std::string& type);
-  std::shared_ptr<VisualizationBase> getInstance(const std::string& type, const std::string& name);
+  bool isValidType(const std::string & type);
+  std::shared_ptr<VisualizationBase> getInstance(
+    const std::string & type,
+    const std::string & name);
 
- private:
-  ros::NodeHandle& nodeHandle_;
+private:
+  ros::NodeHandle & nodeHandle_;
   std::vector<std::string> types_;
 };
 
-} /* namespace */
+}  // namespace grid_map_visualization
+#endif  // GRID_MAP_VISUALIZATION__VISUALIZATIONS__VISUALIZATIONFACTORY_HPP_

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationFactory.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationFactory.hpp
@@ -21,7 +21,7 @@ namespace grid_map_visualization
 class VisualizationFactory
 {
 public:
-  explicit VisualizationFactory(rclcpp::Node::SharedPtr node);
+  VisualizationFactory();
   virtual ~VisualizationFactory();
 
   bool isValidType(const std::string & type);
@@ -31,7 +31,6 @@ public:
     const std::string & name);
 
 private:
-  rclcpp::Node::SharedPtr node_;
   std::vector<std::string> types_;
 };
 

--- a/grid_map_visualization/package.xml
+++ b/grid_map_visualization/package.xml
@@ -14,18 +14,17 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>grid_map_cmake_helpers</build_depend>
 
-  <depend>roscpp</depend>
   <depend>grid_map_core</depend>
-  <depend>grid_map_ros</depend>
   <depend>grid_map_msgs</depend>
-  <depend>tf</depend>
-  <depend>visualization_msgs</depend>
-  <depend>sensor_msgs</depend>
+  <depend>grid_map_ros</depend>
   <depend>nav_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>visualization_msgs</depend>
+  <depend>rclcpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
   
   <export>
     <build_type>ament_cmake</build_type>

--- a/grid_map_visualization/package.xml
+++ b/grid_map_visualization/package.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>grid_map_visualization</name>
-  <version>1.6.2</version>
+  <version>2.0.0</version>
   <description>Configurable tool to visualize grid maps in RViz.</description>
   <maintainer email="mwulf@anybotics.com">Maximilian Wulf</maintainer>
   <maintainer email="ynava@anybotics.com">Yoshua Nava</maintainer>
@@ -9,7 +10,10 @@
   <url type="website">http://github.com/anybotics/grid_map</url>
   <url type="bugtracker">http://github.com/anybotics/grid_map/issues</url>
   <author email="pfankhauser@anybotics.com">Péter Fankhauser</author>
-  <buildtool_depend>catkin</buildtool_depend>
+  
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>grid_map_cmake_helpers</build_depend>
+
   <depend>roscpp</depend>
   <depend>grid_map_core</depend>
   <depend>grid_map_ros</depend>
@@ -18,4 +22,12 @@
   <depend>visualization_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>nav_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/grid_map_visualization/package.xml
+++ b/grid_map_visualization/package.xml
@@ -18,9 +18,9 @@
   <depend>grid_map_msgs</depend>
   <depend>grid_map_ros</depend>
   <depend>nav_msgs</depend>
+  <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>rclcpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/grid_map_visualization/src/GridMapVisualization.cpp
+++ b/grid_map_visualization/src/GridMapVisualization.cpp
@@ -87,13 +87,13 @@ bool GridMapVisualization::readParameters()
       RCLCPP_ERROR(
         nodeHandle_->get_logger(),
         "%s: A visualization with the name '%s' already exists.",
-        visualizationsParameter_.c_str(), namei.c_str());
+        visualizationsParameter_.c_str(), name.c_str());
       return false;
     }
 
     nodeHandle_->declare_parameter(name + ".type");
     try {
-      if (nodeHandle_->get_parameter(name + ".type", type)) {
+      if (!nodeHandle_->get_parameter(name + ".type", type)) {
         RCLCPP_ERROR(
           nodeHandle_->get_logger(),
           "%s: Could not add a visualization because no type was given",
@@ -103,8 +103,8 @@ bool GridMapVisualization::readParameters()
     } catch (const rclcpp::ParameterTypeException & e) {
       RCLCPP_ERROR(
         nodeHandle_->get_logger(),
-        "%s: Could not add %s visualization, because the %s.type parameter is not a string.",
-        visualizationsParameter_.c_str(), name.c_str(), name.c_str());
+        "Could not add %s visualization, because the %s.type parameter is not a string.",
+        name.c_str(), name.c_str());
       return false;
     }
 
@@ -112,12 +112,12 @@ bool GridMapVisualization::readParameters()
     if (!factory_->isValidType(type)) {
       RCLCPP_ERROR(
         nodeHandle_->get_logger(),
-        "Could not find visualization of type '%s'.",
-        type.c_str());
+        "Could not add %s visualization, no visualization of type '%s' found.",
+        name.c_str(), type.c_str());
       return false;
     }
 
-    auto visualization = factory_->getInstance(name, type);
+    auto visualization = factory_->getInstance(type, name);
     visualization->readParameters();
     visualizations_.push_back(visualization);
     RCLCPP_INFO(

--- a/grid_map_visualization/src/GridMapVisualization.cpp
+++ b/grid_map_visualization/src/GridMapVisualization.cpp
@@ -9,11 +9,11 @@
 #include <grid_map_core/GridMap.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
 
-#include <string>
-#include <vector>
-#include <memory>
 #include <chrono>
+#include <memory>
+#include <string>
 #include <unordered_set>
+#include <vector>
 
 #include "grid_map_visualization/GridMapVisualization.hpp"
 
@@ -123,7 +123,7 @@ bool GridMapVisualization::readParameters()
 
 bool GridMapVisualization::initialize()
 {
-  for (auto visualization : visualizations_) {
+  for (auto & visualization : visualizations_) {
     visualization->initialize();
   }
 
@@ -167,8 +167,8 @@ void GridMapVisualization::callback(const grid_map_msgs::msg::GridMap::SharedPtr
   grid_map::GridMap map;
   grid_map::GridMapRosConverter::fromMessage(*message, map);
 
-  for (std::size_t i = 0; i < visualizations_.size(); i++) {
-    visualizations_[i]->visualize(map);
+  for (auto & visualization : visualizations_) {
+    visualization->visualize(map);
   }
 }
 

--- a/grid_map_visualization/src/GridMapVisualization.cpp
+++ b/grid_map_visualization/src/GridMapVisualization.cpp
@@ -24,13 +24,13 @@ GridMapVisualization::GridMapVisualization(const std::string & parameterName)
 : visualizationsParameter_(parameterName)
   // isSubscribed_(false)
 {
-  nodeHandle_ = std::make_shared<rclcpp::Node>("grid_map_visualization");
-  factory_ = std::make_shared<VisualizationFactory>(nodeHandle_);
+  node_ = std::make_shared<rclcpp::Node>("grid_map_visualization");
+  factory_ = std::make_shared<VisualizationFactory>(node_);
 
-  RCLCPP_INFO(nodeHandle_->get_logger(), "Grid map visualization node started.");
+  RCLCPP_INFO(node_->get_logger(), "Grid map visualization node started.");
   readParameters();
 
-  activityCheckTimer_ = nodeHandle_->create_wall_timer(
+  activityCheckTimer_ = node_->create_wall_timer(
     std::chrono::duration<double>(1.0 / activityCheckRate_),
     std::bind(&GridMapVisualization::updateSubscriptionCallback, this));
   initialize();
@@ -43,25 +43,25 @@ GridMapVisualization::~GridMapVisualization()
 rclcpp::Node::SharedPtr
 GridMapVisualization::get_node_ptr()
 {
-  return nodeHandle_;
+  return node_;
 }
 
 bool GridMapVisualization::readParameters()
 {
-  nodeHandle_->declare_parameter("grid_map_topic", std::string("/grid_map"));
-  nodeHandle_->declare_parameter("activity_check_rate", 2.0);
-  nodeHandle_->declare_parameter(visualizationsParameter_, std::vector<std::string>());
+  node_->declare_parameter("grid_map_topic", std::string("/grid_map"));
+  node_->declare_parameter("activity_check_rate", 2.0);
+  node_->declare_parameter(visualizationsParameter_, std::vector<std::string>());
 
-  nodeHandle_->get_parameter("grid_map_topic", mapTopic_);
-  nodeHandle_->get_parameter("activity_check_rate", activityCheckRate_);
+  node_->get_parameter("grid_map_topic", mapTopic_);
+  node_->get_parameter("activity_check_rate", activityCheckRate_);
 
   assert(activityCheckRate_);
 
   // Configure the visualizations from a configuration stored on the parameter server.
   std::vector<std::string> config;
-  if (!nodeHandle_->get_parameter(visualizationsParameter_, config)) {
+  if (!node_->get_parameter(visualizationsParameter_, config)) {
     RCLCPP_WARN(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "Could not load the visualizations configuration from parameter %s,are you sure it"
       "was pushed to the parameter server? Assuming that you meant to leave it empty.",
       visualizationsParameter_.c_str());
@@ -79,24 +79,24 @@ bool GridMapVisualization::readParameters()
       config_check.insert(name);
     } else {
       RCLCPP_ERROR(
-        nodeHandle_->get_logger(),
+        node_->get_logger(),
         "%s: A visualization with the name '%s' already exists.",
         visualizationsParameter_.c_str(), name.c_str());
       return false;
     }
 
-    nodeHandle_->declare_parameter(name + ".type");
+    node_->declare_parameter(name + ".type");
     try {
-      if (!nodeHandle_->get_parameter(name + ".type", type)) {
+      if (!node_->get_parameter(name + ".type", type)) {
         RCLCPP_ERROR(
-          nodeHandle_->get_logger(),
+          node_->get_logger(),
           "%s: Could not add a visualization because no type was given",
           name.c_str());
         return false;
       }
     } catch (const rclcpp::ParameterTypeException & e) {
       RCLCPP_ERROR(
-        nodeHandle_->get_logger(),
+        node_->get_logger(),
         "Could not add %s visualization, because the %s.type parameter is not a string.",
         name.c_str(), name.c_str());
       return false;
@@ -105,7 +105,7 @@ bool GridMapVisualization::readParameters()
     // Make sure the visualization has a valid type.
     if (!factory_->isValidType(type)) {
       RCLCPP_ERROR(
-        nodeHandle_->get_logger(),
+        node_->get_logger(),
         "Could not add %s visualization, no visualization of type '%s' found.",
         name.c_str(), type.c_str());
       return false;
@@ -115,7 +115,7 @@ bool GridMapVisualization::readParameters()
     visualization->readParameters();
     visualizations_.push_back(visualization);
     RCLCPP_INFO(
-      nodeHandle_->get_logger(), "%s: Configured visualization of type '%s' with name '%s'.",
+      node_->get_logger(), "%s: Configured visualization of type '%s' with name '%s'.",
       visualizationsParameter_.c_str(), type.c_str(), name.c_str());
   }
   return true;
@@ -128,7 +128,7 @@ bool GridMapVisualization::initialize()
   }
 
   updateSubscriptionCallback();
-  RCLCPP_INFO(nodeHandle_->get_logger(), "Grid map visualization initialized.");
+  RCLCPP_INFO(node_->get_logger(), "Grid map visualization initialized.");
   return true;
 }
 
@@ -144,24 +144,24 @@ void GridMapVisualization::updateSubscriptionCallback()
   }
 
   if (!isSubscribed_ && isActive) {
-    mapSubscriber_ = nodeHandle_->create_subscription<grid_map_msgs::msg::GridMap>(
+    mapSubscriber_ = node_->create_subscription<grid_map_msgs::msg::GridMap>(
       mapTopic_, rclcpp::SystemDefaultsQoS(),
       std::bind(&GridMapVisualization::callback, this, std::placeholders::_1));
 
     isSubscribed_ = true;
-    RCLCPP_DEBUG(nodeHandle_->get_logger(), "Subscribed to grid map at '%s'.", mapTopic_.c_str());
+    RCLCPP_DEBUG(node_->get_logger(), "Subscribed to grid map at '%s'.", mapTopic_.c_str());
   }
   if (isSubscribed_ && !isActive) {
     mapSubscriber_.reset();
     isSubscribed_ = false;
-    RCLCPP_DEBUG(nodeHandle_->get_logger(), "Cancelled subscription to grid map.");
+    RCLCPP_DEBUG(node_->get_logger(), "Cancelled subscription to grid map.");
   }
 }
 
 void GridMapVisualization::callback(const grid_map_msgs::msg::GridMap::SharedPtr message)
 {
   RCLCPP_DEBUG(
-    nodeHandle_->get_logger(),
+    node_->get_logger(),
     "Grid map visualization received a map (timestamp %f) for visualization.",
     rclcpp::Time(message->header.stamp).seconds());
   grid_map::GridMap map;

--- a/grid_map_visualization/src/GridMapVisualization.cpp
+++ b/grid_map_visualization/src/GridMapVisualization.cpp
@@ -10,23 +10,25 @@
 #include <grid_map_core/GridMap.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
 
-using namespace std;
-using namespace ros;
+#include <string>
 
-namespace grid_map_visualization {
+namespace grid_map_visualization
+{
 
-GridMapVisualization::GridMapVisualization(ros::NodeHandle& nodeHandle,
-                                           const std::string& parameterName)
-    : nodeHandle_(nodeHandle),
-      visualizationsParameter_(parameterName),
-      factory_(nodeHandle_),
-      isSubscribed_(false)
+GridMapVisualization::GridMapVisualization(
+  ros::NodeHandle & nodeHandle,
+  const std::string & parameterName)
+: nodeHandle_(nodeHandle),
+  visualizationsParameter_(parameterName),
+  factory_(nodeHandle_),
+  isSubscribed_(false)
 {
   ROS_INFO("Grid map visualization node started.");
   readParameters();
-  activityCheckTimer_ = nodeHandle_.createTimer(activityCheckDuration_,
-                                                &GridMapVisualization::updateSubscriptionCallback,
-                                                this);
+  activityCheckTimer_ = nodeHandle_.createTimer(
+    activityCheckDuration_,
+    &GridMapVisualization::updateSubscriptionCallback,
+    this);
   initialize();
 }
 
@@ -47,16 +49,17 @@ bool GridMapVisualization::readParameters()
   XmlRpc::XmlRpcValue config;
   if (!nodeHandle_.getParam(visualizationsParameter_, config)) {
     ROS_WARN(
-        "Could not load the visualizations configuration from parameter %s,are you sure it"
-        "was pushed to the parameter server? Assuming that you meant to leave it empty.",
-        visualizationsParameter_.c_str());
+      "Could not load the visualizations configuration from parameter %s,are you sure it"
+      "was pushed to the parameter server? Assuming that you meant to leave it empty.",
+      visualizationsParameter_.c_str());
     return false;
   }
 
   // Verify proper naming and structure,
   if (config.getType() != XmlRpc::XmlRpcValue::TypeArray) {
-    ROS_ERROR("%s: The visualization specification must be a list, but it is of XmlRpcType %d",
-              visualizationsParameter_.c_str(), config.getType());
+    ROS_ERROR(
+      "%s: The visualization specification must be a list, but it is of XmlRpcType %d",
+      visualizationsParameter_.c_str(), config.getType());
     ROS_ERROR("The XML passed in is formatted as follows:\n %s", config.toXml().c_str());
     return false;
   }
@@ -64,39 +67,46 @@ bool GridMapVisualization::readParameters()
   // Iterate over all visualizations (may be just one),
   for (unsigned int i = 0; i < config.size(); ++i) {
     if (config[i].getType() != XmlRpc::XmlRpcValue::TypeStruct) {
-      ROS_ERROR("%s: Visualizations must be specified as maps, but they are XmlRpcType:%d",
-                visualizationsParameter_.c_str(), config[i].getType());
+      ROS_ERROR(
+        "%s: Visualizations must be specified as maps, but they are XmlRpcType:%d",
+        visualizationsParameter_.c_str(), config[i].getType());
       return false;
     } else if (!config[i].hasMember("type")) {
-      ROS_ERROR("%s: Could not add a visualization because no type was given",
-                visualizationsParameter_.c_str());
+      ROS_ERROR(
+        "%s: Could not add a visualization because no type was given",
+        visualizationsParameter_.c_str());
       return false;
     } else if (!config[i].hasMember("name")) {
-      ROS_ERROR("%s: Could not add a visualization because no name was given",
-                visualizationsParameter_.c_str());
+      ROS_ERROR(
+        "%s: Could not add a visualization because no name was given",
+        visualizationsParameter_.c_str());
       return false;
     } else {
-      //Check for name collisions within the list itself.
+      // Check for name collisions within the list itself.
       for (int j = i + 1; j < config.size(); ++j) {
         if (config[j].getType() != XmlRpc::XmlRpcValue::TypeStruct) {
-          ROS_ERROR("%s: Visualizations must be specified as maps, but they are XmlRpcType:%d",
-                    visualizationsParameter_.c_str(), config[j].getType());
+          ROS_ERROR(
+            "%s: Visualizations must be specified as maps, but they are XmlRpcType:%d",
+            visualizationsParameter_.c_str(), config[j].getType());
           return false;
         }
 
-        if (!config[j].hasMember("name")
-            || config[i]["name"].getType() != XmlRpc::XmlRpcValue::TypeString
-            || config[j]["name"].getType() != XmlRpc::XmlRpcValue::TypeString) {
-          ROS_ERROR("%s: Visualizations names must be strings, but they are XmlRpcTypes:%d and %d",
-                    visualizationsParameter_.c_str(), config[i].getType(), config[j].getType());
+        if (!config[j].hasMember("name") ||
+          config[i]["name"].getType() != XmlRpc::XmlRpcValue::TypeString ||
+          config[j]["name"].getType() != XmlRpc::XmlRpcValue::TypeString)
+        {
+          ROS_ERROR(
+            "%s: Visualizations names must be strings, but they are XmlRpcTypes:%d and %d",
+            visualizationsParameter_.c_str(), config[i].getType(), config[j].getType());
           return false;
         }
 
         std::string namei = config[i]["name"];
         std::string namej = config[j]["name"];
         if (namei == namej) {
-          ROS_ERROR("%s: A visualization with the name '%s' already exists.",
-                    visualizationsParameter_.c_str(), namei.c_str());
+          ROS_ERROR(
+            "%s: A visualization with the name '%s' already exists.",
+            visualizationsParameter_.c_str(), namei.c_str());
           return false;
         }
       }
@@ -104,7 +114,9 @@ bool GridMapVisualization::readParameters()
 
     // Make sure the visualization has a valid type.
     if (!factory_.isValidType(config[i]["type"])) {
-      ROS_ERROR("Could not find visualization of type '%s'.", std::string(config[i]["type"]).c_str());
+      ROS_ERROR(
+        "Could not find visualization of type '%s'.",
+        std::string(config[i]["type"]).c_str());
       return false;
     }
   }
@@ -115,8 +127,9 @@ bool GridMapVisualization::readParameters()
     auto visualization = factory_.getInstance(type, name);
     visualization->readParameters(config[i]);
     visualizations_.push_back(visualization);
-    ROS_INFO("%s: Configured visualization of type '%s' with name '%s'.",
-             visualizationsParameter_.c_str(), type.c_str(), name.c_str());
+    ROS_INFO(
+      "%s: Configured visualization of type '%s' with name '%s'.",
+      visualizationsParameter_.c_str(), type.c_str(), name.c_str());
   }
 
   return true;
@@ -124,7 +137,7 @@ bool GridMapVisualization::readParameters()
 
 bool GridMapVisualization::initialize()
 {
-  for (auto& visualization : visualizations_) {
+  for (auto & visualization : visualizations_) {
     visualization->initialize();
   }
   updateSubscriptionCallback(ros::TimerEvent());
@@ -132,11 +145,11 @@ bool GridMapVisualization::initialize()
   return true;
 }
 
-void GridMapVisualization::updateSubscriptionCallback(const ros::TimerEvent&)
+void GridMapVisualization::updateSubscriptionCallback(const ros::TimerEvent &)
 {
   bool isActive = false;
 
-  for (auto& visualization : visualizations_) {
+  for (auto & visualization : visualizations_) {
     if (visualization->isActive()) {
       isActive = true;
       break;
@@ -155,16 +168,17 @@ void GridMapVisualization::updateSubscriptionCallback(const ros::TimerEvent&)
   }
 }
 
-void GridMapVisualization::callback(const grid_map_msgs::GridMap& message)
+void GridMapVisualization::callback(const grid_map_msgs::GridMap & message)
 {
-  ROS_DEBUG("Grid map visualization received a map (timestamp %f) for visualization.",
-            message.info.header.stamp.toSec());
+  ROS_DEBUG(
+    "Grid map visualization received a map (timestamp %f) for visualization.",
+    message.info.header.stamp.toSec());
   grid_map::GridMap map;
   grid_map::GridMapRosConverter::fromMessage(message, map);
 
-  for (auto& visualization : visualizations_) {
+  for (auto & visualization : visualizations_) {
     visualization->visualize(map);
   }
 }
 
-} /* namespace */
+}  // namespace grid_map_visualization

--- a/grid_map_visualization/src/GridMapVisualization.cpp
+++ b/grid_map_visualization/src/GridMapVisualization.cpp
@@ -21,16 +21,16 @@ namespace grid_map_visualization
 {
 
 GridMapVisualization::GridMapVisualization(const std::string & parameterName)
-: visualizationsParameter_(parameterName)
-  // isSubscribed_(false)
+: Node("grid_map_visualization"),
+  visualizationsParameter_(parameterName),
+  isSubscribed_(false)
 {
-  node_ = std::make_shared<rclcpp::Node>("grid_map_visualization");
-  factory_ = std::make_shared<VisualizationFactory>(node_);
+  factory_ = std::make_shared<VisualizationFactory>();
 
-  RCLCPP_INFO(node_->get_logger(), "Grid map visualization node started.");
+  RCLCPP_INFO(this->get_logger(), "Grid map visualization node started.");
   readParameters();
 
-  activityCheckTimer_ = node_->create_wall_timer(
+  activityCheckTimer_ = this->create_wall_timer(
     std::chrono::duration<double>(1.0 / activityCheckRate_),
     std::bind(&GridMapVisualization::updateSubscriptionCallback, this));
   initialize();
@@ -40,28 +40,22 @@ GridMapVisualization::~GridMapVisualization()
 {
 }
 
-rclcpp::Node::SharedPtr
-GridMapVisualization::get_node_ptr()
-{
-  return node_;
-}
-
 bool GridMapVisualization::readParameters()
 {
-  node_->declare_parameter("grid_map_topic", std::string("/grid_map"));
-  node_->declare_parameter("activity_check_rate", 2.0);
-  node_->declare_parameter(visualizationsParameter_, std::vector<std::string>());
+  this->declare_parameter("grid_map_topic", std::string("/grid_map"));
+  this->declare_parameter("activity_check_rate", 2.0);
+  this->declare_parameter(visualizationsParameter_, std::vector<std::string>());
 
-  node_->get_parameter("grid_map_topic", mapTopic_);
-  node_->get_parameter("activity_check_rate", activityCheckRate_);
+  this->get_parameter("grid_map_topic", mapTopic_);
+  this->get_parameter("activity_check_rate", activityCheckRate_);
 
   assert(activityCheckRate_);
 
   // Configure the visualizations from a configuration stored on the parameter server.
   std::vector<std::string> config;
-  if (!node_->get_parameter(visualizationsParameter_, config)) {
+  if (!this->get_parameter(visualizationsParameter_, config)) {
     RCLCPP_WARN(
-      node_->get_logger(),
+      this->get_logger(),
       "Could not load the visualizations configuration from parameter %s,are you sure it"
       "was pushed to the parameter server? Assuming that you meant to leave it empty.",
       visualizationsParameter_.c_str());
@@ -79,24 +73,24 @@ bool GridMapVisualization::readParameters()
       config_check.insert(name);
     } else {
       RCLCPP_ERROR(
-        node_->get_logger(),
+        this->get_logger(),
         "%s: A visualization with the name '%s' already exists.",
         visualizationsParameter_.c_str(), name.c_str());
       return false;
     }
 
-    node_->declare_parameter(name + ".type");
+    this->declare_parameter(name + ".type");
     try {
-      if (!node_->get_parameter(name + ".type", type)) {
+      if (!this->get_parameter(name + ".type", type)) {
         RCLCPP_ERROR(
-          node_->get_logger(),
+          this->get_logger(),
           "%s: Could not add a visualization because no type was given",
           name.c_str());
         return false;
       }
     } catch (const rclcpp::ParameterTypeException & e) {
       RCLCPP_ERROR(
-        node_->get_logger(),
+        this->get_logger(),
         "Could not add %s visualization, because the %s.type parameter is not a string.",
         name.c_str(), name.c_str());
       return false;
@@ -105,7 +99,7 @@ bool GridMapVisualization::readParameters()
     // Make sure the visualization has a valid type.
     if (!factory_->isValidType(type)) {
       RCLCPP_ERROR(
-        node_->get_logger(),
+        this->get_logger(),
         "Could not add %s visualization, no visualization of type '%s' found.",
         name.c_str(), type.c_str());
       return false;
@@ -115,7 +109,7 @@ bool GridMapVisualization::readParameters()
     visualization->readParameters();
     visualizations_.push_back(visualization);
     RCLCPP_INFO(
-      node_->get_logger(), "%s: Configured visualization of type '%s' with name '%s'.",
+      this->get_logger(), "%s: Configured visualization of type '%s' with name '%s'.",
       visualizationsParameter_.c_str(), type.c_str(), name.c_str());
   }
   return true;
@@ -128,7 +122,7 @@ bool GridMapVisualization::initialize()
   }
 
   updateSubscriptionCallback();
-  RCLCPP_INFO(node_->get_logger(), "Grid map visualization initialized.");
+  RCLCPP_INFO(this->get_logger(), "Grid map visualization initialized.");
   return true;
 }
 
@@ -144,24 +138,24 @@ void GridMapVisualization::updateSubscriptionCallback()
   }
 
   if (!isSubscribed_ && isActive) {
-    mapSubscriber_ = node_->create_subscription<grid_map_msgs::msg::GridMap>(
+    mapSubscriber_ = this->create_subscription<grid_map_msgs::msg::GridMap>(
       mapTopic_, rclcpp::SystemDefaultsQoS(),
       std::bind(&GridMapVisualization::callback, this, std::placeholders::_1));
 
     isSubscribed_ = true;
-    RCLCPP_DEBUG(node_->get_logger(), "Subscribed to grid map at '%s'.", mapTopic_.c_str());
+    RCLCPP_DEBUG(this->get_logger(), "Subscribed to grid map at '%s'.", mapTopic_.c_str());
   }
   if (isSubscribed_ && !isActive) {
     mapSubscriber_.reset();
     isSubscribed_ = false;
-    RCLCPP_DEBUG(node_->get_logger(), "Cancelled subscription to grid map.");
+    RCLCPP_DEBUG(this->get_logger(), "Cancelled subscription to grid map.");
   }
 }
 
 void GridMapVisualization::callback(const grid_map_msgs::msg::GridMap::SharedPtr message)
 {
   RCLCPP_DEBUG(
-    node_->get_logger(),
+    this->get_logger(),
     "Grid map visualization received a map (timestamp %f) for visualization.",
     rclcpp::Time(message->header.stamp).seconds());
   grid_map::GridMap map;

--- a/grid_map_visualization/src/GridMapVisualizationHelpers.cpp
+++ b/grid_map_visualization/src/GridMapVisualizationHelpers.cpp
@@ -11,75 +11,102 @@
 #include <grid_map_ros/GridMapMsgHelpers.hpp>
 #include <grid_map_core/GridMapMath.hpp>
 
-using namespace Eigen;
+#include <algorithm>
 
-namespace grid_map_visualization {
+namespace grid_map_visualization
+{
 
-void getColorMessageFromColorVector(std_msgs::ColorRGBA& colorMessage, const Eigen::Vector3f& colorVector, bool resetTransparency)
+void getColorMessageFromColorVector(
+  std_msgs::ColorRGBA & colorMessage,
+  const Eigen::Vector3f & colorVector, bool resetTransparency)
 {
   colorMessage.r = colorVector(0);
   colorMessage.g = colorVector(1);
   colorMessage.b = colorVector(2);
-  if (resetTransparency) colorMessage.a = 1.0;
+  if (resetTransparency) {colorMessage.a = 1.0;}
 }
 
-void getColorVectorFromColorMessage(Eigen::Vector3f& colorVector, const std_msgs::ColorRGBA& colorMessage)
+void getColorVectorFromColorMessage(
+  Eigen::Vector3f & colorVector,
+  const std_msgs::ColorRGBA & colorMessage)
 {
   colorVector << colorMessage.r, colorMessage.g, colorMessage.b;
 }
 
-void setColorFromColorValue(std_msgs::ColorRGBA& color, const unsigned long& colorValue, bool resetTransparency)
+void setColorFromColorValue(
+  std_msgs::ColorRGBA & color, const unsigned int64 & colorValue,
+  bool resetTransparency)
 {
   Vector3f colorVector;
   grid_map::colorValueToVector(colorValue, colorVector);
   getColorMessageFromColorVector(color, colorVector, resetTransparency);
 }
 
-void setColorChannelFromValue(float& colorChannel, const double value, const double lowerValueBound,
-                              const double upperValueBound, const bool invert, const double colorChannelLowerValue,
-                              const double colorChannelUpperValue)
+void setColorChannelFromValue(
+  float & colorChannel, const double value, const double lowerValueBound,
+  const double upperValueBound, const bool invert, const double colorChannelLowerValue,
+  const double colorChannelUpperValue)
 {
   float tempColorChannelLowerValue = colorChannelLowerValue;
   float tempColorChannelUpperValue = colorChannelUpperValue;
 
-  if (invert)
-  {
+  if (invert) {
     tempColorChannelLowerValue = colorChannelUpperValue;
     tempColorChannelUpperValue = colorChannelLowerValue;
   }
 
-  colorChannel = static_cast<float>(computeLinearMapping(value, lowerValueBound, upperValueBound, tempColorChannelLowerValue, tempColorChannelUpperValue));
+  colorChannel =
+    static_cast<float>(computeLinearMapping(
+      value, lowerValueBound, upperValueBound,
+      tempColorChannelLowerValue, tempColorChannelUpperValue));
 }
 
-void interpolateBetweenColors(std_msgs::ColorRGBA& color, const std_msgs::ColorRGBA& colorForLowerValue,
-                              const std_msgs::ColorRGBA& colorForUpperValue, const double value,
-                              const double lowerValueBound, const double upperValueBound)
+void interpolateBetweenColors(
+  std_msgs::ColorRGBA & color, const std_msgs::ColorRGBA & colorForLowerValue,
+  const std_msgs::ColorRGBA & colorForUpperValue, const double value,
+  const double lowerValueBound, const double upperValueBound)
 {
-  setColorChannelFromValue(color.r, value, lowerValueBound, upperValueBound, false, colorForLowerValue.r, colorForUpperValue.r);
-  setColorChannelFromValue(color.g, value, lowerValueBound, upperValueBound, false, colorForLowerValue.g, colorForUpperValue.g);
-  setColorChannelFromValue(color.b, value, lowerValueBound, upperValueBound, false, colorForLowerValue.b, colorForUpperValue.b);
+  setColorChannelFromValue(
+    color.r, value, lowerValueBound, upperValueBound, false,
+    colorForLowerValue.r, colorForUpperValue.r);
+  setColorChannelFromValue(
+    color.g, value, lowerValueBound, upperValueBound, false,
+    colorForLowerValue.g, colorForUpperValue.g);
+  setColorChannelFromValue(
+    color.b, value, lowerValueBound, upperValueBound, false,
+    colorForLowerValue.b, colorForUpperValue.b);
 }
 
-void setSaturationFromValue(std_msgs::ColorRGBA& color, const double value, const double lowerValueBound,
-                            const double upperValueBound, const double maxSaturation, const double minSaturation)
+void setSaturationFromValue(
+  std_msgs::ColorRGBA & color, const double value, const double lowerValueBound,
+  const double upperValueBound, const double maxSaturation, const double minSaturation)
 {
   // Based on "changeSaturation" function by Darel Rex Finley.
-  const Eigen::Array3f HspFactors(.299, .587, .114); // see http://alienryderflex.com/hsp.html
-  float saturationChange = static_cast<float>(computeLinearMapping(value, value, upperValueBound, maxSaturation, minSaturation));
+  const Eigen::Array3f HspFactors(.299, .587, .114);  // see http://alienryderflex.com/hsp.html
+  float saturationChange =
+    static_cast<float>(computeLinearMapping(
+      value, value, upperValueBound, maxSaturation,
+      minSaturation));
   Vector3f colorVector;
   getColorVectorFromColorMessage(colorVector, color);
   float perceivedBrightness = sqrt((colorVector.array().square() * HspFactors).sum());
-  colorVector = perceivedBrightness + saturationChange * (colorVector.array() - perceivedBrightness);
+  colorVector = perceivedBrightness + saturationChange *
+    (colorVector.array() - perceivedBrightness);
   colorVector = (colorVector.array().min(Array3f::Ones())).matrix();
   getColorMessageFromColorVector(color, colorVector, false);
 }
 
-void setColorFromValue(std_msgs::ColorRGBA& color, const double value, const double lowerValueBound, const double upperValueBound)
+void setColorFromValue(
+  std_msgs::ColorRGBA & color, const double value,
+  const double lowerValueBound, const double upperValueBound)
 {
-  Vector3f hsl; // Hue: [0, 2 Pi], Saturation and Lightness: [0, 1]
+  Vector3f hsl;  // Hue: [0, 2 Pi], Saturation and Lightness: [0, 1]
   Vector3f rgb;
 
-  hsl[0] = static_cast<float>(computeLinearMapping(value, lowerValueBound, upperValueBound, 0.0, 2.0 * M_PI));
+  hsl[0] =
+    static_cast<float>(computeLinearMapping(
+      value, lowerValueBound, upperValueBound, 0.0,
+      2.0 * M_PI));
   hsl[1] = 1.0;
   hsl[2] = 1.0;
 
@@ -94,23 +121,20 @@ void setColorFromValue(std_msgs::ColorRGBA& color, const double value, const dou
 }
 
 double computeLinearMapping(
-    const double& sourceValue, const double& sourceLowerValue, const double& sourceUpperValue,
-    const double& mapLowerValue, const double& mapUpperValue)
+  const double & sourceValue, const double & sourceLowerValue, const double & sourceUpperValue,
+  const double & mapLowerValue, const double & mapUpperValue)
 {
   double m = (mapLowerValue - mapUpperValue) / (sourceLowerValue - sourceUpperValue);
   double b = mapUpperValue - m * sourceUpperValue;
   double mapValue = m * sourceValue + b;
-  if (mapLowerValue < mapUpperValue)
-  {
+  if (mapLowerValue < mapUpperValue) {
     mapValue = std::max(mapValue, mapLowerValue);
     mapValue = std::min(mapValue, mapUpperValue);
-  }
-  else
-  {
+  } else {
     mapValue = std::min(mapValue, mapLowerValue);
     mapValue = std::max(mapValue, mapUpperValue);
   }
   return mapValue;
 }
 
-} /* namespace */
+}  // namespace grid_map_visualization

--- a/grid_map_visualization/src/GridMapVisualizationHelpers.cpp
+++ b/grid_map_visualization/src/GridMapVisualizationHelpers.cpp
@@ -8,8 +8,8 @@
 
 #include "grid_map_visualization/GridMapVisualizationHelpers.hpp"
 
-#include <grid_map_ros/GridMapMsgHelpers.hpp>
 #include <grid_map_core/GridMapMath.hpp>
+#include <grid_map_ros/GridMapMsgHelpers.hpp>
 
 #include <algorithm>
 

--- a/grid_map_visualization/src/GridMapVisualizationHelpers.cpp
+++ b/grid_map_visualization/src/GridMapVisualizationHelpers.cpp
@@ -17,7 +17,7 @@ namespace grid_map_visualization
 {
 
 void getColorMessageFromColorVector(
-  std_msgs::ColorRGBA & colorMessage,
+  std_msgs::msg::ColorRGBA & colorMessage,
   const Eigen::Vector3f & colorVector, bool resetTransparency)
 {
   colorMessage.r = colorVector(0);
@@ -28,16 +28,16 @@ void getColorMessageFromColorVector(
 
 void getColorVectorFromColorMessage(
   Eigen::Vector3f & colorVector,
-  const std_msgs::ColorRGBA & colorMessage)
+  const std_msgs::msg::ColorRGBA & colorMessage)
 {
   colorVector << colorMessage.r, colorMessage.g, colorMessage.b;
 }
 
 void setColorFromColorValue(
-  std_msgs::ColorRGBA & color, const unsigned int64 & colorValue,
+  std_msgs::msg::ColorRGBA & color, const uint64_t & colorValue,
   bool resetTransparency)
 {
-  Vector3f colorVector;
+  Eigen::Vector3f colorVector;
   grid_map::colorValueToVector(colorValue, colorVector);
   getColorMessageFromColorVector(color, colorVector, resetTransparency);
 }
@@ -62,8 +62,8 @@ void setColorChannelFromValue(
 }
 
 void interpolateBetweenColors(
-  std_msgs::ColorRGBA & color, const std_msgs::ColorRGBA & colorForLowerValue,
-  const std_msgs::ColorRGBA & colorForUpperValue, const double value,
+  std_msgs::msg::ColorRGBA & color, const std_msgs::msg::ColorRGBA & colorForLowerValue,
+  const std_msgs::msg::ColorRGBA & colorForUpperValue, const double value,
   const double lowerValueBound, const double upperValueBound)
 {
   setColorChannelFromValue(
@@ -78,30 +78,31 @@ void interpolateBetweenColors(
 }
 
 void setSaturationFromValue(
-  std_msgs::ColorRGBA & color, const double value, const double lowerValueBound,
+  std_msgs::msg::ColorRGBA & color, const double value, const double lowerValueBound,
   const double upperValueBound, const double maxSaturation, const double minSaturation)
 {
+  (void) lowerValueBound;  // unused argument
   // Based on "changeSaturation" function by Darel Rex Finley.
   const Eigen::Array3f HspFactors(.299, .587, .114);  // see http://alienryderflex.com/hsp.html
   float saturationChange =
     static_cast<float>(computeLinearMapping(
       value, value, upperValueBound, maxSaturation,
       minSaturation));
-  Vector3f colorVector;
+  Eigen::Vector3f colorVector;
   getColorVectorFromColorMessage(colorVector, color);
   float perceivedBrightness = sqrt((colorVector.array().square() * HspFactors).sum());
   colorVector = perceivedBrightness + saturationChange *
     (colorVector.array() - perceivedBrightness);
-  colorVector = (colorVector.array().min(Array3f::Ones())).matrix();
+  colorVector = (colorVector.array().min(Eigen::Array3f::Ones())).matrix();
   getColorMessageFromColorVector(color, colorVector, false);
 }
 
 void setColorFromValue(
-  std_msgs::ColorRGBA & color, const double value,
+  std_msgs::msg::ColorRGBA & color, const double value,
   const double lowerValueBound, const double upperValueBound)
 {
-  Vector3f hsl;  // Hue: [0, 2 Pi], Saturation and Lightness: [0, 1]
-  Vector3f rgb;
+  Eigen::Vector3f hsl;  // Hue: [0, 2 Pi], Saturation and Lightness: [0, 1]
+  Eigen::Vector3f rgb;
 
   hsl[0] =
     static_cast<float>(computeLinearMapping(
@@ -111,9 +112,10 @@ void setColorFromValue(
   hsl[2] = 1.0;
 
   float offset = 2.0 / 3.0 * M_PI;
-  Array3f rgbOffset(0, -offset, offset);
-  rgb = ((rgbOffset + hsl[0]).cos() + 0.5).min(Array3f::Ones()).max(Array3f::Zero()) * hsl[2];
-  float white = Vector3f(0.3, 0.59, 0.11).transpose() * rgb;
+  Eigen::Array3f rgbOffset(0, -offset, offset);
+  rgb = ((rgbOffset + hsl[0]).cos() + 0.5).min(Eigen::Array3f::Ones()).max(Eigen::Array3f::Zero()) *
+    hsl[2];
+  float white = Eigen::Vector3f(0.3, 0.59, 0.11).transpose() * rgb;
   float saturation = 1.0 - hsl[1];
   rgb = rgb + ((-rgb.array() + white) * saturation).matrix();
 

--- a/grid_map_visualization/src/grid_map_visualization_node.cpp
+++ b/grid_map_visualization/src/grid_map_visualization_node.cpp
@@ -6,18 +6,17 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#include <ros/ros.h>
-#include "grid_map_visualization/GridMapVisualization.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <grid_map_visualization/GridMapVisualization.hpp>
+
+#include <memory>
 
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "grid_map_visualization");
-
-  ros::NodeHandle nodeHandle("~");
-
-  grid_map_visualization::GridMapVisualization gridMapVisualization(nodeHandle,
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<grid_map_visualization::GridMapVisualization>(
     "grid_map_visualizations");
-
-  ros::spin();
+  rclcpp::spin(node->get_node_ptr());
+  rclcpp::shutdown();
   return 0;
 }

--- a/grid_map_visualization/src/grid_map_visualization_node.cpp
+++ b/grid_map_visualization/src/grid_map_visualization_node.cpp
@@ -16,7 +16,7 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
   auto node = std::make_shared<grid_map_visualization::GridMapVisualization>(
     "grid_map_visualizations");
-  rclcpp::spin(node->get_node_ptr());
+  rclcpp::spin(node->get_node_base_interface());
   rclcpp::shutdown();
   return 0;
 }

--- a/grid_map_visualization/src/grid_map_visualization_node.cpp
+++ b/grid_map_visualization/src/grid_map_visualization_node.cpp
@@ -9,13 +9,14 @@
 #include <ros/ros.h>
 #include "grid_map_visualization/GridMapVisualization.hpp"
 
-int main(int argc, char** argv)
+int main(int argc, char ** argv)
 {
   ros::init(argc, argv, "grid_map_visualization");
 
   ros::NodeHandle nodeHandle("~");
 
-  grid_map_visualization::GridMapVisualization gridMapVisualization(nodeHandle, "grid_map_visualizations");
+  grid_map_visualization::GridMapVisualization gridMapVisualization(nodeHandle,
+    "grid_map_visualizations");
 
   ros::spin();
   return 0;

--- a/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
@@ -18,9 +18,9 @@ namespace grid_map_visualization
 {
 
 FlatPointCloudVisualization::FlatPointCloudVisualization(
-  rclcpp::Node::SharedPtr nodeHandle,
+  rclcpp::Node::SharedPtr node,
   const std::string & name)
-: VisualizationBase(nodeHandle, name),
+: VisualizationBase(node, name),
   height_(0.0)
 {
 }
@@ -32,10 +32,10 @@ FlatPointCloudVisualization::~FlatPointCloudVisualization()
 bool FlatPointCloudVisualization::readParameters()
 {
   height_ = 0.0;
-  nodeHandle_->declare_parameter(name_ + ".params.height", 0.0);
-  if (!nodeHandle_->get_parameter(name_ + ".params.height", height_)) {
+  node_->declare_parameter(name_ + ".params.height", 0.0);
+  if (!node_->get_parameter(name_ + ".params.height", height_)) {
     RCLCPP_INFO(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "FlatPointCloudVisualization with name '%s' "
       "did not find a 'height' parameter. Using default.",
       name_.c_str());
@@ -46,7 +46,7 @@ bool FlatPointCloudVisualization::readParameters()
 
 bool FlatPointCloudVisualization::initialize()
 {
-  publisher_ = nodeHandle_->create_publisher<sensor_msgs::msg::PointCloud2>(name_, 1);
+  publisher_ = node_->create_publisher<sensor_msgs::msg::PointCloud2>(name_, 1);
   return true;
 }
 

--- a/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
@@ -11,11 +11,16 @@
 
 #include <sensor_msgs/PointCloud2.h>
 
-namespace grid_map_visualization {
+#include <string>
 
-FlatPointCloudVisualization::FlatPointCloudVisualization(ros::NodeHandle& nodeHandle, const std::string& name)
-    : VisualizationBase(nodeHandle, name),
-      height_(0.0)
+namespace grid_map_visualization
+{
+
+FlatPointCloudVisualization::FlatPointCloudVisualization(
+  ros::NodeHandle & nodeHandle,
+  const std::string & name)
+: VisualizationBase(nodeHandle, name),
+  height_(0.0)
 {
 }
 
@@ -23,13 +28,16 @@ FlatPointCloudVisualization::~FlatPointCloudVisualization()
 {
 }
 
-bool FlatPointCloudVisualization::readParameters(XmlRpc::XmlRpcValue& config)
+bool FlatPointCloudVisualization::readParameters(XmlRpc::XmlRpcValue & config)
 {
   VisualizationBase::readParameters(config);
 
   height_ = 0.0;
   if (!getParam("height", height_)) {
-    ROS_INFO("FlatPointCloudVisualization with name '%s' did not find a 'height' parameter. Using default.", name_.c_str());
+    ROS_INFO(
+      "FlatPointCloudVisualization with name '%s' "
+      "did not find a 'height' parameter. Using default.",
+      name_.c_str());
   }
 
   return true;
@@ -41,9 +49,9 @@ bool FlatPointCloudVisualization::initialize()
   return true;
 }
 
-bool FlatPointCloudVisualization::visualize(const grid_map::GridMap& map)
+bool FlatPointCloudVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) return true;
+  if (!isActive()) {return true;}
   sensor_msgs::PointCloud2 pointCloud;
 
   grid_map::GridMap mapCopy(map);
@@ -54,4 +62,4 @@ bool FlatPointCloudVisualization::visualize(const grid_map::GridMap& map)
   return true;
 }
 
-} /* namespace */
+}  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
@@ -32,7 +32,8 @@ FlatPointCloudVisualization::~FlatPointCloudVisualization()
 bool FlatPointCloudVisualization::readParameters()
 {
   height_ = 0.0;
-  if (!nodeHandle_->get_parameter(name_ + "height", height_)) {
+  nodeHandle_->declare_parameter(name_ + ".params.height", 0.0);
+  if (!nodeHandle_->get_parameter(name_ + ".params.height", height_)) {
     RCLCPP_INFO(
       nodeHandle_->get_logger(),
       "FlatPointCloudVisualization with name '%s' "
@@ -45,7 +46,7 @@ bool FlatPointCloudVisualization::readParameters()
 
 bool FlatPointCloudVisualization::initialize()
 {
-  publisher_ = nodeHandle_->create_publisher<sensor_msgs::msg::PointCloud2>(name_, 10);
+  publisher_ = nodeHandle_->create_publisher<sensor_msgs::msg::PointCloud2>(name_, 1);
   return true;
 }
 

--- a/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
@@ -46,13 +46,15 @@ bool FlatPointCloudVisualization::readParameters()
 
 bool FlatPointCloudVisualization::initialize()
 {
-  publisher_ = node_->create_publisher<sensor_msgs::msg::PointCloud2>(name_, 1);
+  publisher_ = node_->create_publisher<sensor_msgs::msg::PointCloud2>(
+    name_,
+    rclcpp::QoS(1).transient_local());
   return true;
 }
 
 bool FlatPointCloudVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) {return true;}
+  if (!isActive()) {return false;}
   sensor_msgs::msg::PointCloud2 pointCloud;
 
   grid_map::GridMap mapCopy(map);

--- a/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
@@ -52,7 +52,7 @@ bool FlatPointCloudVisualization::initialize()
 
 bool FlatPointCloudVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive(name_)) {return true;}
+  if (!isActive()) {return true;}
   sensor_msgs::msg::PointCloud2 pointCloud;
 
   grid_map::GridMap mapCopy(map);

--- a/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/FlatPointCloudVisualization.cpp
@@ -17,10 +17,8 @@
 namespace grid_map_visualization
 {
 
-FlatPointCloudVisualization::FlatPointCloudVisualization(
-  rclcpp::Node::SharedPtr node,
-  const std::string & name)
-: VisualizationBase(node, name),
+FlatPointCloudVisualization::FlatPointCloudVisualization(const std::string & name)
+: VisualizationBase(name),
   height_(0.0)
 {
 }
@@ -32,13 +30,13 @@ FlatPointCloudVisualization::~FlatPointCloudVisualization()
 bool FlatPointCloudVisualization::readParameters()
 {
   height_ = 0.0;
-  node_->declare_parameter(name_ + ".params.height", 0.0);
-  if (!node_->get_parameter(name_ + ".params.height", height_)) {
+  this->declare_parameter(std::string(this->get_name()) + ".params.height", 0.0);
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.height", height_)) {
     RCLCPP_INFO(
-      node_->get_logger(),
+      this->get_logger(),
       "FlatPointCloudVisualization with name '%s' "
       "did not find a 'height' parameter. Using default.",
-      name_.c_str());
+      this->get_name());
   }
 
   return true;
@@ -46,8 +44,8 @@ bool FlatPointCloudVisualization::readParameters()
 
 bool FlatPointCloudVisualization::initialize()
 {
-  publisher_ = node_->create_publisher<sensor_msgs::msg::PointCloud2>(
-    name_,
+  publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
+    this->get_name(),
     rclcpp::QoS(1).transient_local());
   return true;
 }

--- a/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
@@ -32,7 +32,11 @@ GridCellsVisualization::~GridCellsVisualization()
 
 bool GridCellsVisualization::readParameters()
 {
-  if (!nodeHandle_->get_parameter(name_ + "layer", layer_)) {
+  nodeHandle_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
+  nodeHandle_->declare_parameter(name_ + ".params.lower_threshold", 5.0);
+  nodeHandle_->declare_parameter(name_ + ".params.upper_threshold", -5.0);
+
+  if (!nodeHandle_->get_parameter(name_ + ".params.layer", layer_)) {
     RCLCPP_ERROR(
       nodeHandle_->get_logger(),
       "GridCellsVisualization with name '%s' did not find a 'layer' parameter.",
@@ -40,7 +44,7 @@ bool GridCellsVisualization::readParameters()
     return false;
   }
 
-  if (!nodeHandle_->get_parameter(name_ + "lower_threshold", lowerThreshold_)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.lower_threshold", lowerThreshold_)) {
     RCLCPP_INFO(
       nodeHandle_->get_logger(),
       "GridCellsVisualization with name '%s' "
@@ -48,7 +52,7 @@ bool GridCellsVisualization::readParameters()
       name_.c_str());
   }
 
-  if (!nodeHandle_->get_parameter(name_ + "upper_threshold", upperThreshold_)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.upper_threshold", upperThreshold_)) {
     RCLCPP_INFO(
       nodeHandle_->get_logger(),
       "GridCellsVisualization with name '%s' "
@@ -61,7 +65,7 @@ bool GridCellsVisualization::readParameters()
 
 bool GridCellsVisualization::initialize()
 {
-  publisher_ = nodeHandle_->create_publisher<nav_msgs::msg::GridCells>(name_, 10);
+  publisher_ = nodeHandle_->create_publisher<nav_msgs::msg::GridCells>(name_, 1);
   return true;
 }
 

--- a/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
@@ -71,7 +71,7 @@ bool GridCellsVisualization::initialize()
 
 bool GridCellsVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive(name_)) {return true;}
+  if (!isActive()) {return true;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
       nodeHandle_->get_logger(),

--- a/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
@@ -8,7 +8,7 @@
 
 #include "grid_map_visualization/visualizations/GridCellsVisualization.hpp"
 #include <grid_map_ros/GridMapRosConverter.hpp>
-#include <nav_msgs/GridCells.h>
+#include <nav_msgs/msg/grid_cells.hpp>
 
 // STD
 #include <string>
@@ -18,7 +18,7 @@ namespace grid_map_visualization
 {
 
 GridCellsVisualization::GridCellsVisualization(
-  ros::NodeHandle & nodeHandle,
+  rclcpp::Node::SharedPtr nodeHandle,
   const std::string & name)
 : VisualizationBase(nodeHandle, name),
   lowerThreshold_(-std::numeric_limits<float>::infinity()),
@@ -30,26 +30,27 @@ GridCellsVisualization::~GridCellsVisualization()
 {
 }
 
-bool GridCellsVisualization::readParameters(XmlRpc::XmlRpcValue & config)
+bool GridCellsVisualization::readParameters()
 {
-  VisualizationBase::readParameters(config);
-
-  if (!getParam("layer", layer_)) {
-    ROS_ERROR(
+  if (!nodeHandle_->get_parameter(name_ + "layer", layer_)) {
+    RCLCPP_ERROR(
+      nodeHandle_->get_logger(),
       "GridCellsVisualization with name '%s' did not find a 'layer' parameter.",
       name_.c_str());
     return false;
   }
 
-  if (!getParam("lower_threshold", lowerThreshold_)) {
-    ROS_INFO(
+  if (!nodeHandle_->get_parameter(name_ + "lower_threshold", lowerThreshold_)) {
+    RCLCPP_INFO(
+      nodeHandle_->get_logger(),
       "GridCellsVisualization with name '%s' "
       "did not find a 'lower_threshold' parameter. Using negative infinity.",
       name_.c_str());
   }
 
-  if (!getParam("upper_threshold", upperThreshold_)) {
-    ROS_INFO(
+  if (!nodeHandle_->get_parameter(name_ + "upper_threshold", upperThreshold_)) {
+    RCLCPP_INFO(
+      nodeHandle_->get_logger(),
       "GridCellsVisualization with name '%s' "
       "did not find a 'upper_threshold' parameter. Using infinity.",
       name_.c_str());
@@ -60,23 +61,24 @@ bool GridCellsVisualization::readParameters(XmlRpc::XmlRpcValue & config)
 
 bool GridCellsVisualization::initialize()
 {
-  publisher_ = nodeHandle_.advertise<nav_msgs::GridCells>(name_, 1, true);
+  publisher_ = nodeHandle_->create_publisher<nav_msgs::msg::GridCells>(name_, 10);
   return true;
 }
 
 bool GridCellsVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) {return true;}
+  if (!isActive(name_)) {return true;}
   if (!map.exists(layer_)) {
-    ROS_WARN_STREAM(
+    RCLCPP_WARN_STREAM(
+      nodeHandle_->get_logger(),
       "GridCellsVisualization::visualize: No grid map layer with name '" << layer_ << "' found.");
     return false;
   }
-  nav_msgs::GridCells gridCells;
+  nav_msgs::msg::GridCells gridCells;
   grid_map::GridMapRosConverter::toGridCells(
     map, layer_, lowerThreshold_, upperThreshold_,
     gridCells);
-  publisher_.publish(gridCells);
+  publisher_->publish(gridCells);
   return true;
 }
 

--- a/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
@@ -11,8 +11,8 @@
 #include <nav_msgs/msg/grid_cells.hpp>
 
 // STD
-#include <string>
 #include <limits>
+#include <string>
 
 namespace grid_map_visualization
 {
@@ -65,13 +65,15 @@ bool GridCellsVisualization::readParameters()
 
 bool GridCellsVisualization::initialize()
 {
-  publisher_ = node_->create_publisher<nav_msgs::msg::GridCells>(name_, 1);
+  publisher_ = node_->create_publisher<nav_msgs::msg::GridCells>(
+    name_,
+    rclcpp::QoS(1).transient_local());
   return true;
 }
 
 bool GridCellsVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) {return true;}
+  if (!isActive()) {return false;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
       node_->get_logger(),

--- a/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
@@ -11,11 +11,15 @@
 #include <nav_msgs/GridCells.h>
 
 // STD
+#include <string>
 #include <limits>
 
-namespace grid_map_visualization {
+namespace grid_map_visualization
+{
 
-GridCellsVisualization::GridCellsVisualization(ros::NodeHandle& nodeHandle, const std::string& name)
+GridCellsVisualization::GridCellsVisualization(
+  ros::NodeHandle & nodeHandle,
+  const std::string & name)
 : VisualizationBase(nodeHandle, name),
   lowerThreshold_(-std::numeric_limits<float>::infinity()),
   upperThreshold_(std::numeric_limits<float>::infinity())
@@ -26,21 +30,29 @@ GridCellsVisualization::~GridCellsVisualization()
 {
 }
 
-bool GridCellsVisualization::readParameters(XmlRpc::XmlRpcValue& config)
+bool GridCellsVisualization::readParameters(XmlRpc::XmlRpcValue & config)
 {
   VisualizationBase::readParameters(config);
 
   if (!getParam("layer", layer_)) {
-    ROS_ERROR("GridCellsVisualization with name '%s' did not find a 'layer' parameter.", name_.c_str());
+    ROS_ERROR(
+      "GridCellsVisualization with name '%s' did not find a 'layer' parameter.",
+      name_.c_str());
     return false;
   }
 
   if (!getParam("lower_threshold", lowerThreshold_)) {
-    ROS_INFO("GridCellsVisualization with name '%s' did not find a 'lower_threshold' parameter. Using negative infinity.", name_.c_str());
+    ROS_INFO(
+      "GridCellsVisualization with name '%s' "
+      "did not find a 'lower_threshold' parameter. Using negative infinity.",
+      name_.c_str());
   }
 
   if (!getParam("upper_threshold", upperThreshold_)) {
-    ROS_INFO("GridCellsVisualization with name '%s' did not find a 'upper_threshold' parameter. Using infinity.", name_.c_str());
+    ROS_INFO(
+      "GridCellsVisualization with name '%s' "
+      "did not find a 'upper_threshold' parameter. Using infinity.",
+      name_.c_str());
   }
 
   return true;
@@ -52,17 +64,20 @@ bool GridCellsVisualization::initialize()
   return true;
 }
 
-bool GridCellsVisualization::visualize(const grid_map::GridMap& map)
+bool GridCellsVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) return true;
+  if (!isActive()) {return true;}
   if (!map.exists(layer_)) {
-    ROS_WARN_STREAM("GridCellsVisualization::visualize: No grid map layer with name '" << layer_ << "' found.");
+    ROS_WARN_STREAM(
+      "GridCellsVisualization::visualize: No grid map layer with name '" << layer_ << "' found.");
     return false;
   }
   nav_msgs::GridCells gridCells;
-  grid_map::GridMapRosConverter::toGridCells(map, layer_, lowerThreshold_, upperThreshold_, gridCells);
+  grid_map::GridMapRosConverter::toGridCells(
+    map, layer_, lowerThreshold_, upperThreshold_,
+    gridCells);
   publisher_.publish(gridCells);
   return true;
 }
 
-} /* namespace */
+}  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
@@ -17,10 +17,8 @@
 namespace grid_map_visualization
 {
 
-GridCellsVisualization::GridCellsVisualization(
-  rclcpp::Node::SharedPtr node,
-  const std::string & name)
-: VisualizationBase(node, name),
+GridCellsVisualization::GridCellsVisualization(const std::string & name)
+: VisualizationBase(name),
   lowerThreshold_(-std::numeric_limits<float>::infinity()),
   upperThreshold_(std::numeric_limits<float>::infinity())
 {
@@ -32,32 +30,40 @@ GridCellsVisualization::~GridCellsVisualization()
 
 bool GridCellsVisualization::readParameters()
 {
-  node_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
-  node_->declare_parameter(name_ + ".params.lower_threshold", 5.0);
-  node_->declare_parameter(name_ + ".params.upper_threshold", -5.0);
+  this->declare_parameter(
+    std::string(this->get_name()) + ".params.layer",
+    std::string("elevation"));
+  this->declare_parameter(std::string(this->get_name()) + ".params.lower_threshold", 5.0);
+  this->declare_parameter(std::string(this->get_name()) + ".params.upper_threshold", -5.0);
 
-  if (!node_->get_parameter(name_ + ".params.layer", layer_)) {
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.layer", layer_)) {
     RCLCPP_ERROR(
-      node_->get_logger(),
+      this->get_logger(),
       "GridCellsVisualization with name '%s' did not find a 'layer' parameter.",
-      name_.c_str());
+      this->get_name());
     return false;
   }
 
-  if (!node_->get_parameter(name_ + ".params.lower_threshold", lowerThreshold_)) {
+  if (!this->get_parameter(
+      std::string(this->get_name()) + ".params.lower_threshold",
+      lowerThreshold_))
+  {
     RCLCPP_INFO(
-      node_->get_logger(),
+      this->get_logger(),
       "GridCellsVisualization with name '%s' "
       "did not find a 'lower_threshold' parameter. Using negative infinity.",
-      name_.c_str());
+      this->get_name());
   }
 
-  if (!node_->get_parameter(name_ + ".params.upper_threshold", upperThreshold_)) {
+  if (!this->get_parameter(
+      std::string(this->get_name()) + ".params.upper_threshold",
+      upperThreshold_))
+  {
     RCLCPP_INFO(
-      node_->get_logger(),
+      this->get_logger(),
       "GridCellsVisualization with name '%s' "
       "did not find a 'upper_threshold' parameter. Using infinity.",
-      name_.c_str());
+      this->get_name());
   }
 
   return true;
@@ -65,8 +71,8 @@ bool GridCellsVisualization::readParameters()
 
 bool GridCellsVisualization::initialize()
 {
-  publisher_ = node_->create_publisher<nav_msgs::msg::GridCells>(
-    name_,
+  publisher_ = this->create_publisher<nav_msgs::msg::GridCells>(
+    this->get_name(),
     rclcpp::QoS(1).transient_local());
   return true;
 }
@@ -76,7 +82,7 @@ bool GridCellsVisualization::visualize(const grid_map::GridMap & map)
   if (!isActive()) {return false;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
-      node_->get_logger(),
+      this->get_logger(),
       "GridCellsVisualization::visualize: No grid map layer with name '" << layer_ << "' found.");
     return false;
   }

--- a/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/GridCellsVisualization.cpp
@@ -18,9 +18,9 @@ namespace grid_map_visualization
 {
 
 GridCellsVisualization::GridCellsVisualization(
-  rclcpp::Node::SharedPtr nodeHandle,
+  rclcpp::Node::SharedPtr node,
   const std::string & name)
-: VisualizationBase(nodeHandle, name),
+: VisualizationBase(node, name),
   lowerThreshold_(-std::numeric_limits<float>::infinity()),
   upperThreshold_(std::numeric_limits<float>::infinity())
 {
@@ -32,29 +32,29 @@ GridCellsVisualization::~GridCellsVisualization()
 
 bool GridCellsVisualization::readParameters()
 {
-  nodeHandle_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
-  nodeHandle_->declare_parameter(name_ + ".params.lower_threshold", 5.0);
-  nodeHandle_->declare_parameter(name_ + ".params.upper_threshold", -5.0);
+  node_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
+  node_->declare_parameter(name_ + ".params.lower_threshold", 5.0);
+  node_->declare_parameter(name_ + ".params.upper_threshold", -5.0);
 
-  if (!nodeHandle_->get_parameter(name_ + ".params.layer", layer_)) {
+  if (!node_->get_parameter(name_ + ".params.layer", layer_)) {
     RCLCPP_ERROR(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "GridCellsVisualization with name '%s' did not find a 'layer' parameter.",
       name_.c_str());
     return false;
   }
 
-  if (!nodeHandle_->get_parameter(name_ + ".params.lower_threshold", lowerThreshold_)) {
+  if (!node_->get_parameter(name_ + ".params.lower_threshold", lowerThreshold_)) {
     RCLCPP_INFO(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "GridCellsVisualization with name '%s' "
       "did not find a 'lower_threshold' parameter. Using negative infinity.",
       name_.c_str());
   }
 
-  if (!nodeHandle_->get_parameter(name_ + ".params.upper_threshold", upperThreshold_)) {
+  if (!node_->get_parameter(name_ + ".params.upper_threshold", upperThreshold_)) {
     RCLCPP_INFO(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "GridCellsVisualization with name '%s' "
       "did not find a 'upper_threshold' parameter. Using infinity.",
       name_.c_str());
@@ -65,7 +65,7 @@ bool GridCellsVisualization::readParameters()
 
 bool GridCellsVisualization::initialize()
 {
-  publisher_ = nodeHandle_->create_publisher<nav_msgs::msg::GridCells>(name_, 1);
+  publisher_ = node_->create_publisher<nav_msgs::msg::GridCells>(name_, 1);
   return true;
 }
 
@@ -74,7 +74,7 @@ bool GridCellsVisualization::visualize(const grid_map::GridMap & map)
   if (!isActive()) {return true;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "GridCellsVisualization::visualize: No grid map layer with name '" << layer_ << "' found.");
     return false;
   }

--- a/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
@@ -18,9 +18,9 @@ namespace grid_map_visualization
 {
 
 MapRegionVisualization::MapRegionVisualization(
-  rclcpp::Node::SharedPtr nodeHandle,
+  rclcpp::Node::SharedPtr node,
   const std::string & name)
-: VisualizationBase(nodeHandle, name),
+: VisualizationBase(node, name),
   nVertices_(5),
   lineWidth_(0.01)
 {
@@ -32,21 +32,21 @@ MapRegionVisualization::~MapRegionVisualization()
 
 bool MapRegionVisualization::readParameters()
 {
-  nodeHandle_->declare_parameter(name_ + ".params.line_width", 0.003);
-  nodeHandle_->declare_parameter(name_ + ".params.color", 16777215);
+  node_->declare_parameter(name_ + ".params.line_width", 0.003);
+  node_->declare_parameter(name_ + ".params.color", 16777215);
   lineWidth_ = 0.003;
-  if (!nodeHandle_->get_parameter(name_ + ".params.line_width", lineWidth_)) {
+  if (!node_->get_parameter(name_ + ".params.line_width", lineWidth_)) {
     RCLCPP_INFO(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "MapRegionVisualization with name '%s' did not find a 'line_width' parameter. Using default.",
       name_.c_str());
     return false;
   }
 
   int colorValue = 16777215;  // white, http://www.wolframalpha.com/input/?i=BitOr%5BBitShiftLeft%5Br%2C16%5D%2C+BitShiftLeft%5Bg%2C8%5D%2C+b%5D+where+%7Br%3D20%2C+g%3D50%2C+b%3D230%7D  // NOLINT
-  if (!nodeHandle_->get_parameter(name_ + ".params.color", colorValue)) {
+  if (!node_->get_parameter(name_ + ".params.color", colorValue)) {
     RCLCPP_INFO(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "MapRegionVisualization with name '%s' did not find a 'color' parameter. Using default.",
       name_.c_str());
   }
@@ -64,7 +64,7 @@ bool MapRegionVisualization::initialize()
   marker_.scale.x = lineWidth_;
   marker_.points.resize(nVertices_);  // Initialized to [0.0, 0.0, 0.0]
   marker_.colors.resize(nVertices_, color_);
-  publisher_ = nodeHandle_->create_publisher<visualization_msgs::msg::Marker>(name_, 1);
+  publisher_ = node_->create_publisher<visualization_msgs::msg::Marker>(name_, 1);
   return true;
 }
 

--- a/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
@@ -64,13 +64,15 @@ bool MapRegionVisualization::initialize()
   marker_.scale.x = lineWidth_;
   marker_.points.resize(nVertices_);  // Initialized to [0.0, 0.0, 0.0]
   marker_.colors.resize(nVertices_, color_);
-  publisher_ = node_->create_publisher<visualization_msgs::msg::Marker>(name_, 1);
+  publisher_ = node_->create_publisher<visualization_msgs::msg::Marker>(
+    name_,
+    rclcpp::QoS(1).transient_local());
   return true;
 }
 
 bool MapRegionVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) {return true;}
+  if (!isActive()) {return false;}
 
   // TODO(needs_assignment): Replace this with ploygon?
 

--- a/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
@@ -17,10 +17,8 @@
 namespace grid_map_visualization
 {
 
-MapRegionVisualization::MapRegionVisualization(
-  rclcpp::Node::SharedPtr node,
-  const std::string & name)
-: VisualizationBase(node, name),
+MapRegionVisualization::MapRegionVisualization(const std::string & name)
+: VisualizationBase(name),
   nVertices_(5),
   lineWidth_(0.01)
 {
@@ -32,23 +30,23 @@ MapRegionVisualization::~MapRegionVisualization()
 
 bool MapRegionVisualization::readParameters()
 {
-  node_->declare_parameter(name_ + ".params.line_width", 0.003);
-  node_->declare_parameter(name_ + ".params.color", 16777215);
+  this->declare_parameter(std::string(this->get_name()) + ".params.line_width", 0.003);
+  this->declare_parameter(std::string(this->get_name()) + ".params.color", 16777215);
   lineWidth_ = 0.003;
-  if (!node_->get_parameter(name_ + ".params.line_width", lineWidth_)) {
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.line_width", lineWidth_)) {
     RCLCPP_INFO(
-      node_->get_logger(),
+      this->get_logger(),
       "MapRegionVisualization with name '%s' did not find a 'line_width' parameter. Using default.",
-      name_.c_str());
+      this->get_name());
     return false;
   }
 
   int colorValue = 16777215;  // white, http://www.wolframalpha.com/input/?i=BitOr%5BBitShiftLeft%5Br%2C16%5D%2C+BitShiftLeft%5Bg%2C8%5D%2C+b%5D+where+%7Br%3D20%2C+g%3D50%2C+b%3D230%7D  // NOLINT
-  if (!node_->get_parameter(name_ + ".params.color", colorValue)) {
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.color", colorValue)) {
     RCLCPP_INFO(
-      node_->get_logger(),
+      this->get_logger(),
       "MapRegionVisualization with name '%s' did not find a 'color' parameter. Using default.",
-      name_.c_str());
+      this->get_name());
   }
   setColorFromColorValue(color_, colorValue, true);
 
@@ -64,8 +62,8 @@ bool MapRegionVisualization::initialize()
   marker_.scale.x = lineWidth_;
   marker_.points.resize(nVertices_);  // Initialized to [0.0, 0.0, 0.0]
   marker_.colors.resize(nVertices_, color_);
-  publisher_ = node_->create_publisher<visualization_msgs::msg::Marker>(
-    name_,
+  publisher_ = this->create_publisher<visualization_msgs::msg::Marker>(
+    this->get_name(),
     rclcpp::QoS(1).transient_local());
   return true;
 }

--- a/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
@@ -12,12 +12,17 @@
 // ROS
 #include <geometry_msgs/Point.h>
 
-namespace grid_map_visualization {
+#include <string>
 
-MapRegionVisualization::MapRegionVisualization(ros::NodeHandle& nodeHandle, const std::string& name)
-    : VisualizationBase(nodeHandle, name),
-      nVertices_(5),
-      lineWidth_(0.01)
+namespace grid_map_visualization
+{
+
+MapRegionVisualization::MapRegionVisualization(
+  ros::NodeHandle & nodeHandle,
+  const std::string & name)
+: VisualizationBase(nodeHandle, name),
+  nVertices_(5),
+  lineWidth_(0.01)
 {
 }
 
@@ -25,18 +30,22 @@ MapRegionVisualization::~MapRegionVisualization()
 {
 }
 
-bool MapRegionVisualization::readParameters(XmlRpc::XmlRpcValue& config)
+bool MapRegionVisualization::readParameters(XmlRpc::XmlRpcValue & config)
 {
   VisualizationBase::readParameters(config);
 
   lineWidth_ = 0.003;
   if (!getParam("line_width", lineWidth_)) {
-    ROS_INFO("MapRegionVisualization with name '%s' did not find a 'line_width' parameter. Using default.", name_.c_str());
+    ROS_INFO(
+      "MapRegionVisualization with name '%s' did not find a 'line_width' parameter. Using default.",
+      name_.c_str());
   }
 
-  int colorValue = 16777215; // white, http://www.wolframalpha.com/input/?i=BitOr%5BBitShiftLeft%5Br%2C16%5D%2C+BitShiftLeft%5Bg%2C8%5D%2C+b%5D+where+%7Br%3D20%2C+g%3D50%2C+b%3D230%7D
+  int colorValue = 16777215;  // white, http://www.wolframalpha.com/input/?i=BitOr%5BBitShiftLeft%5Br%2C16%5D%2C+BitShiftLeft%5Bg%2C8%5D%2C+b%5D+where+%7Br%3D20%2C+g%3D50%2C+b%3D230%7D  // NOLINT
   if (!getParam("color", colorValue)) {
-    ROS_INFO("MapRegionVisualization with name '%s' did not find a 'color' parameter. Using default.", name_.c_str());
+    ROS_INFO(
+      "MapRegionVisualization with name '%s' did not find a 'color' parameter. Using default.",
+      name_.c_str());
   }
   setColorFromColorValue(color_, colorValue, true);
 
@@ -50,17 +59,17 @@ bool MapRegionVisualization::initialize()
   marker_.action = visualization_msgs::Marker::ADD;
   marker_.type = visualization_msgs::Marker::LINE_STRIP;
   marker_.scale.x = lineWidth_;
-  marker_.points.resize(nVertices_); // Initialized to [0.0, 0.0, 0.0]
+  marker_.points.resize(nVertices_);  // Initialized to [0.0, 0.0, 0.0]
   marker_.colors.resize(nVertices_, color_);
   publisher_ = nodeHandle_.advertise<visualization_msgs::Marker>(name_, 1, true);
   return true;
 }
 
-bool MapRegionVisualization::visualize(const grid_map::GridMap& map)
+bool MapRegionVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) return true;
+  if (!isActive()) {return true;}
 
-  // TODO Replace this with ploygon?
+  // TODO(needs_assignment): Replace this with ploygon?
 
   // Set marker info.
   marker_.header.frame_id = map.getFrameId();
@@ -85,4 +94,4 @@ bool MapRegionVisualization::visualize(const grid_map::GridMap& map)
   return true;
 }
 
-} /* namespace */
+}  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
@@ -32,8 +32,10 @@ MapRegionVisualization::~MapRegionVisualization()
 
 bool MapRegionVisualization::readParameters()
 {
+  nodeHandle_->declare_parameter(name_ + ".params.line_width", 0.003);
+  nodeHandle_->declare_parameter(name_ + ".params.color", 16777215);
   lineWidth_ = 0.003;
-  if (!nodeHandle_->get_parameter(name_ + "line_width", lineWidth_)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.line_width", lineWidth_)) {
     RCLCPP_INFO(
       nodeHandle_->get_logger(),
       "MapRegionVisualization with name '%s' did not find a 'line_width' parameter. Using default.",
@@ -42,7 +44,7 @@ bool MapRegionVisualization::readParameters()
   }
 
   int colorValue = 16777215;  // white, http://www.wolframalpha.com/input/?i=BitOr%5BBitShiftLeft%5Br%2C16%5D%2C+BitShiftLeft%5Bg%2C8%5D%2C+b%5D+where+%7Br%3D20%2C+g%3D50%2C+b%3D230%7D  // NOLINT
-  if (!nodeHandle_->get_parameter(name_ + "color", colorValue)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.color", colorValue)) {
     RCLCPP_INFO(
       nodeHandle_->get_logger(),
       "MapRegionVisualization with name '%s' did not find a 'color' parameter. Using default.",
@@ -62,7 +64,7 @@ bool MapRegionVisualization::initialize()
   marker_.scale.x = lineWidth_;
   marker_.points.resize(nVertices_);  // Initialized to [0.0, 0.0, 0.0]
   marker_.colors.resize(nVertices_, color_);
-  publisher_ = nodeHandle_->create_publisher<visualization_msgs::msg::Marker>(name_, 10);
+  publisher_ = nodeHandle_->create_publisher<visualization_msgs::msg::Marker>(name_, 1);
   return true;
 }
 

--- a/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
@@ -10,7 +10,7 @@
 #include <grid_map_visualization/GridMapVisualizationHelpers.hpp>
 
 // ROS
-#include <geometry_msgs/Point.h>
+#include <geometry_msgs/msg/point.hpp>
 
 #include <string>
 
@@ -18,7 +18,7 @@ namespace grid_map_visualization
 {
 
 MapRegionVisualization::MapRegionVisualization(
-  ros::NodeHandle & nodeHandle,
+  rclcpp::Node::SharedPtr nodeHandle,
   const std::string & name)
 : VisualizationBase(nodeHandle, name),
   nVertices_(5),
@@ -30,20 +30,21 @@ MapRegionVisualization::~MapRegionVisualization()
 {
 }
 
-bool MapRegionVisualization::readParameters(XmlRpc::XmlRpcValue & config)
+bool MapRegionVisualization::readParameters()
 {
-  VisualizationBase::readParameters(config);
-
   lineWidth_ = 0.003;
-  if (!getParam("line_width", lineWidth_)) {
-    ROS_INFO(
+  if (!nodeHandle_->get_parameter(name_ + "line_width", lineWidth_)) {
+    RCLCPP_INFO(
+      nodeHandle_->get_logger(),
       "MapRegionVisualization with name '%s' did not find a 'line_width' parameter. Using default.",
       name_.c_str());
+    return false;
   }
 
   int colorValue = 16777215;  // white, http://www.wolframalpha.com/input/?i=BitOr%5BBitShiftLeft%5Br%2C16%5D%2C+BitShiftLeft%5Bg%2C8%5D%2C+b%5D+where+%7Br%3D20%2C+g%3D50%2C+b%3D230%7D  // NOLINT
-  if (!getParam("color", colorValue)) {
-    ROS_INFO(
+  if (!nodeHandle_->get_parameter(name_ + "color", colorValue)) {
+    RCLCPP_INFO(
+      nodeHandle_->get_logger(),
       "MapRegionVisualization with name '%s' did not find a 'color' parameter. Using default.",
       name_.c_str());
   }
@@ -55,25 +56,25 @@ bool MapRegionVisualization::readParameters(XmlRpc::XmlRpcValue & config)
 bool MapRegionVisualization::initialize()
 {
   marker_.ns = "map_region";
-  marker_.lifetime = ros::Duration();
-  marker_.action = visualization_msgs::Marker::ADD;
-  marker_.type = visualization_msgs::Marker::LINE_STRIP;
+  marker_.lifetime = rclcpp::Duration(0);  // Setting lifetime to forever
+  marker_.action = visualization_msgs::msg::Marker::ADD;
+  marker_.type = visualization_msgs::msg::Marker::LINE_STRIP;
   marker_.scale.x = lineWidth_;
   marker_.points.resize(nVertices_);  // Initialized to [0.0, 0.0, 0.0]
   marker_.colors.resize(nVertices_, color_);
-  publisher_ = nodeHandle_.advertise<visualization_msgs::Marker>(name_, 1, true);
+  publisher_ = nodeHandle_->create_publisher<visualization_msgs::msg::Marker>(name_, 10);
   return true;
 }
 
 bool MapRegionVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) {return true;}
+  if (!isActive(name_)) {return true;}
 
   // TODO(needs_assignment): Replace this with ploygon?
 
   // Set marker info.
   marker_.header.frame_id = map.getFrameId();
-  marker_.header.stamp.fromNSec(map.getTimestamp());
+  marker_.header.stamp = rclcpp::Time(map.getTimestamp());
 
   // Adapt positions of markers.
   float halfLengthX = map.getLength().x() / 2.0;
@@ -90,7 +91,7 @@ bool MapRegionVisualization::visualize(const grid_map::GridMap & map)
   marker_.points[4].x = marker_.points[0].x;
   marker_.points[4].y = marker_.points[0].y;
 
-  publisher_.publish(marker_);
+  publisher_->publish(marker_);
   return true;
 }
 

--- a/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
@@ -70,7 +70,7 @@ bool MapRegionVisualization::initialize()
 
 bool MapRegionVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive(name_)) {return true;}
+  if (!isActive()) {return true;}
 
   // TODO(needs_assignment): Replace this with ploygon?
 

--- a/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
@@ -10,9 +10,14 @@
 #include <grid_map_ros/GridMapRosConverter.hpp>
 #include <nav_msgs/OccupancyGrid.h>
 
-namespace grid_map_visualization {
+#include <string>
 
-OccupancyGridVisualization::OccupancyGridVisualization(ros::NodeHandle& nodeHandle, const std::string& name)
+namespace grid_map_visualization
+{
+
+OccupancyGridVisualization::OccupancyGridVisualization(
+  ros::NodeHandle & nodeHandle,
+  const std::string & name)
 : VisualizationBase(nodeHandle, name),
   dataMin_(0.0),
   dataMax_(1.0)
@@ -23,22 +28,28 @@ OccupancyGridVisualization::~OccupancyGridVisualization()
 {
 }
 
-bool OccupancyGridVisualization::readParameters(XmlRpc::XmlRpcValue& config)
+bool OccupancyGridVisualization::readParameters(XmlRpc::XmlRpcValue & config)
 {
   VisualizationBase::readParameters(config);
 
   if (!getParam("layer", layer_)) {
-    ROS_ERROR("OccupancyGridVisualization with name '%s' did not find a 'layer' parameter.", name_.c_str());
+    ROS_ERROR(
+      "OccupancyGridVisualization with name '%s' did not find a 'layer' parameter.",
+      name_.c_str());
     return false;
   }
 
   if (!getParam("data_min", dataMin_)) {
-    ROS_ERROR("OccupancyGridVisualization with name '%s' did not find a 'data_min' parameter.", name_.c_str());
+    ROS_ERROR(
+      "OccupancyGridVisualization with name '%s' did not find a 'data_min' parameter.",
+      name_.c_str());
     return false;
   }
 
   if (!getParam("data_max", dataMax_)) {
-    ROS_ERROR("OccupancyGridVisualization with name '%s' did not find a 'data_max' parameter.", name_.c_str());
+    ROS_ERROR(
+      "OccupancyGridVisualization with name '%s' did not find a 'data_max' parameter.",
+      name_.c_str());
     return false;
   }
 
@@ -51,11 +62,13 @@ bool OccupancyGridVisualization::initialize()
   return true;
 }
 
-bool OccupancyGridVisualization::visualize(const grid_map::GridMap& map)
+bool OccupancyGridVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) return true;
+  if (!isActive()) {return true;}
   if (!map.exists(layer_)) {
-    ROS_WARN_STREAM("OccupancyGridVisualization::visualize: No grid map layer with name '" << layer_ << "' found.");
+    ROS_WARN_STREAM(
+      "OccupancyGridVisualization::visualize: No grid map layer with name '" << layer_ <<
+        "' found.");
     return false;
   }
   nav_msgs::OccupancyGrid occupancyGrid;
@@ -64,4 +77,4 @@ bool OccupancyGridVisualization::visualize(const grid_map::GridMap& map)
   return true;
 }
 
-} /* namespace */
+}  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
@@ -15,10 +15,8 @@
 namespace grid_map_visualization
 {
 
-OccupancyGridVisualization::OccupancyGridVisualization(
-  rclcpp::Node::SharedPtr node,
-  const std::string & name)
-: VisualizationBase(node, name),
+OccupancyGridVisualization::OccupancyGridVisualization(const std::string & name)
+: VisualizationBase(name),
   dataMin_(0.0),
   dataMax_(1.0)
 {
@@ -30,31 +28,33 @@ OccupancyGridVisualization::~OccupancyGridVisualization()
 
 bool OccupancyGridVisualization::readParameters()
 {
-  node_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
-  node_->declare_parameter(name_ + ".params.data_min", 0.0);
-  node_->declare_parameter(name_ + ".params.data_max", 1.0);
+  this->declare_parameter(
+    std::string(this->get_name()) + ".params.layer",
+    std::string("elevation"));
+  this->declare_parameter(std::string(this->get_name()) + ".params.data_min", 0.0);
+  this->declare_parameter(std::string(this->get_name()) + ".params.data_max", 1.0);
 
-  if (!node_->get_parameter(name_ + ".params.layer", layer_)) {
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.layer", layer_)) {
     RCLCPP_ERROR(
-      node_->get_logger(),
+      this->get_logger(),
       "OccupancyGridVisualization with name '%s' did not find a 'layer' parameter.",
-      name_.c_str());
+      this->get_name());
     return false;
   }
 
-  if (!node_->get_parameter(name_ + ".params.data_min", dataMin_)) {
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.data_min", dataMin_)) {
     RCLCPP_ERROR(
-      node_->get_logger(),
+      this->get_logger(),
       "OccupancyGridVisualization with name '%s' did not find a 'data_min' parameter.",
-      name_.c_str());
+      this->get_name());
     return false;
   }
 
-  if (!node_->get_parameter(name_ + ".params.data_max", dataMax_)) {
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.data_max", dataMax_)) {
     RCLCPP_ERROR(
-      node_->get_logger(),
+      this->get_logger(),
       "OccupancyGridVisualization with name '%s' did not find a 'data_max' parameter.",
-      name_.c_str());
+      this->get_name());
     return false;
   }
 
@@ -63,8 +63,8 @@ bool OccupancyGridVisualization::readParameters()
 
 bool OccupancyGridVisualization::initialize()
 {
-  publisher_ = node_->create_publisher<nav_msgs::msg::OccupancyGrid>(
-    name_,
+  publisher_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
+    this->get_name(),
     rclcpp::QoS(1).transient_local());
   return true;
 }
@@ -74,7 +74,7 @@ bool OccupancyGridVisualization::visualize(const grid_map::GridMap & map)
   if (!isActive()) {return false;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
-      node_->get_logger(),
+      this->get_logger(),
       "OccupancyGridVisualization::visualize: No grid map layer with name '" << layer_ <<
         "' found.");
     return false;

--- a/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
@@ -16,9 +16,9 @@ namespace grid_map_visualization
 {
 
 OccupancyGridVisualization::OccupancyGridVisualization(
-  rclcpp::Node::SharedPtr nodeHandle,
+  rclcpp::Node::SharedPtr node,
   const std::string & name)
-: VisualizationBase(nodeHandle, name),
+: VisualizationBase(node, name),
   dataMin_(0.0),
   dataMax_(1.0)
 {
@@ -30,29 +30,29 @@ OccupancyGridVisualization::~OccupancyGridVisualization()
 
 bool OccupancyGridVisualization::readParameters()
 {
-  nodeHandle_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
-  nodeHandle_->declare_parameter(name_ + ".params.data_min", 0.0);
-  nodeHandle_->declare_parameter(name_ + ".params.data_max", 1.0);
+  node_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
+  node_->declare_parameter(name_ + ".params.data_min", 0.0);
+  node_->declare_parameter(name_ + ".params.data_max", 1.0);
 
-  if (!nodeHandle_->get_parameter(name_ + ".params.layer", layer_)) {
+  if (!node_->get_parameter(name_ + ".params.layer", layer_)) {
     RCLCPP_ERROR(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "OccupancyGridVisualization with name '%s' did not find a 'layer' parameter.",
       name_.c_str());
     return false;
   }
 
-  if (!nodeHandle_->get_parameter(name_ + ".params.data_min", dataMin_)) {
+  if (!node_->get_parameter(name_ + ".params.data_min", dataMin_)) {
     RCLCPP_ERROR(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "OccupancyGridVisualization with name '%s' did not find a 'data_min' parameter.",
       name_.c_str());
     return false;
   }
 
-  if (!nodeHandle_->get_parameter(name_ + ".params.data_max", dataMax_)) {
+  if (!node_->get_parameter(name_ + ".params.data_max", dataMax_)) {
     RCLCPP_ERROR(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "OccupancyGridVisualization with name '%s' did not find a 'data_max' parameter.",
       name_.c_str());
     return false;
@@ -63,7 +63,7 @@ bool OccupancyGridVisualization::readParameters()
 
 bool OccupancyGridVisualization::initialize()
 {
-  publisher_ = nodeHandle_->create_publisher<nav_msgs::msg::OccupancyGrid>(name_, 1);
+  publisher_ = node_->create_publisher<nav_msgs::msg::OccupancyGrid>(name_, 1);
   return true;
 }
 
@@ -72,7 +72,7 @@ bool OccupancyGridVisualization::visualize(const grid_map::GridMap & map)
   if (!isActive()) {return true;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "OccupancyGridVisualization::visualize: No grid map layer with name '" << layer_ <<
         "' found.");
     return false;

--- a/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
@@ -30,7 +30,11 @@ OccupancyGridVisualization::~OccupancyGridVisualization()
 
 bool OccupancyGridVisualization::readParameters()
 {
-  if (!nodeHandle_->get_parameter(name_ + "layer", layer_)) {
+  nodeHandle_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
+  nodeHandle_->declare_parameter(name_ + ".params.data_min", 0.0);
+  nodeHandle_->declare_parameter(name_ + ".params.data_max", 1.0);
+
+  if (!nodeHandle_->get_parameter(name_ + ".params.layer", layer_)) {
     RCLCPP_ERROR(
       nodeHandle_->get_logger(),
       "OccupancyGridVisualization with name '%s' did not find a 'layer' parameter.",
@@ -38,7 +42,7 @@ bool OccupancyGridVisualization::readParameters()
     return false;
   }
 
-  if (!nodeHandle_->get_parameter(name_ + "data_min", dataMin_)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.data_min", dataMin_)) {
     RCLCPP_ERROR(
       nodeHandle_->get_logger(),
       "OccupancyGridVisualization with name '%s' did not find a 'data_min' parameter.",
@@ -46,7 +50,7 @@ bool OccupancyGridVisualization::readParameters()
     return false;
   }
 
-  if (!nodeHandle_->get_parameter(name_ + "data_max", dataMax_)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.data_max", dataMax_)) {
     RCLCPP_ERROR(
       nodeHandle_->get_logger(),
       "OccupancyGridVisualization with name '%s' did not find a 'data_max' parameter.",

--- a/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
@@ -63,13 +63,15 @@ bool OccupancyGridVisualization::readParameters()
 
 bool OccupancyGridVisualization::initialize()
 {
-  publisher_ = node_->create_publisher<nav_msgs::msg::OccupancyGrid>(name_, 1);
+  publisher_ = node_->create_publisher<nav_msgs::msg::OccupancyGrid>(
+    name_,
+    rclcpp::QoS(1).transient_local());
   return true;
 }
 
 bool OccupancyGridVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) {return true;}
+  if (!isActive()) {return false;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
       node_->get_logger(),

--- a/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/OccupancyGridVisualization.cpp
@@ -69,7 +69,7 @@ bool OccupancyGridVisualization::initialize()
 
 bool OccupancyGridVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive(name_)) {return true;}
+  if (!isActive()) {return true;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
       nodeHandle_->get_logger(),

--- a/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
@@ -27,7 +27,8 @@ PointCloudVisualization::~PointCloudVisualization()
 
 bool PointCloudVisualization::readParameters()
 {
-  if (!nodeHandle_->get_parameter(name_ + "layer", layer_)) {
+  nodeHandle_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
+  if (!nodeHandle_->get_parameter(name_ + ".params.layer", layer_)) {
     RCLCPP_ERROR(
       nodeHandle_->get_logger(),
       "PointCloudVisualization with name '%s' did not find a 'layer' parameter.",
@@ -39,7 +40,7 @@ bool PointCloudVisualization::readParameters()
 
 bool PointCloudVisualization::initialize()
 {
-  publisher_ = nodeHandle_->create_publisher<sensor_msgs::msg::PointCloud2>(name_, 10);
+  publisher_ = nodeHandle_->create_publisher<sensor_msgs::msg::PointCloud2>(name_, 1);
   return true;
 }
 

--- a/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
@@ -40,13 +40,15 @@ bool PointCloudVisualization::readParameters()
 
 bool PointCloudVisualization::initialize()
 {
-  publisher_ = node_->create_publisher<sensor_msgs::msg::PointCloud2>(name_, 1);
+  publisher_ = node_->create_publisher<sensor_msgs::msg::PointCloud2>(
+    name_,
+    rclcpp::QoS(1).transient_local());
   return true;
 }
 
 bool PointCloudVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) {return true;}
+  if (!isActive()) {return false;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
       node_->get_logger(),

--- a/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
@@ -11,10 +11,15 @@
 
 #include <sensor_msgs/PointCloud2.h>
 
-namespace grid_map_visualization {
+#include <string>
 
-PointCloudVisualization::PointCloudVisualization(ros::NodeHandle& nodeHandle, const std::string& name)
-    : VisualizationBase(nodeHandle, name)
+namespace grid_map_visualization
+{
+
+PointCloudVisualization::PointCloudVisualization(
+  ros::NodeHandle & nodeHandle,
+  const std::string & name)
+: VisualizationBase(nodeHandle, name)
 {
 }
 
@@ -22,11 +27,13 @@ PointCloudVisualization::~PointCloudVisualization()
 {
 }
 
-bool PointCloudVisualization::readParameters(XmlRpc::XmlRpcValue& config)
+bool PointCloudVisualization::readParameters(XmlRpc::XmlRpcValue & config)
 {
   VisualizationBase::readParameters(config);
   if (!getParam("layer", layer_)) {
-    ROS_ERROR("PointCloudVisualization with name '%s' did not find a 'layer' parameter.", name_.c_str());
+    ROS_ERROR(
+      "PointCloudVisualization with name '%s' did not find a 'layer' parameter.",
+      name_.c_str());
     return false;
   }
   return true;
@@ -38,11 +45,13 @@ bool PointCloudVisualization::initialize()
   return true;
 }
 
-bool PointCloudVisualization::visualize(const grid_map::GridMap& map)
+bool PointCloudVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) return true;
+  if (!isActive()) {return true;}
   if (!map.exists(layer_)) {
-    ROS_WARN_STREAM("PointCloudVisualization::visualize: No grid map layer with name '" << layer_ << "' found.");
+    ROS_WARN_STREAM(
+      "PointCloudVisualization::visualize: No grid map layer with name '" << layer_ <<
+        "' found.");
     return false;
   }
   sensor_msgs::PointCloud2 pointCloud;
@@ -51,4 +60,4 @@ bool PointCloudVisualization::visualize(const grid_map::GridMap& map)
   return true;
 }
 
-} /* namespace */
+}  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
@@ -15,9 +15,9 @@ namespace grid_map_visualization
 {
 
 PointCloudVisualization::PointCloudVisualization(
-  rclcpp::Node::SharedPtr nodeHandle,
+  rclcpp::Node::SharedPtr node,
   const std::string & name)
-: VisualizationBase(nodeHandle, name)
+: VisualizationBase(node, name)
 {
 }
 
@@ -27,10 +27,10 @@ PointCloudVisualization::~PointCloudVisualization()
 
 bool PointCloudVisualization::readParameters()
 {
-  nodeHandle_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
-  if (!nodeHandle_->get_parameter(name_ + ".params.layer", layer_)) {
+  node_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
+  if (!node_->get_parameter(name_ + ".params.layer", layer_)) {
     RCLCPP_ERROR(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "PointCloudVisualization with name '%s' did not find a 'layer' parameter.",
       name_.c_str());
     return false;
@@ -40,7 +40,7 @@ bool PointCloudVisualization::readParameters()
 
 bool PointCloudVisualization::initialize()
 {
-  publisher_ = nodeHandle_->create_publisher<sensor_msgs::msg::PointCloud2>(name_, 1);
+  publisher_ = node_->create_publisher<sensor_msgs::msg::PointCloud2>(name_, 1);
   return true;
 }
 
@@ -49,7 +49,7 @@ bool PointCloudVisualization::visualize(const grid_map::GridMap & map)
   if (!isActive()) {return true;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "PointCloudVisualization::visualize: No grid map layer with name '" << layer_ <<
         "' found.");
     return false;

--- a/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
@@ -14,10 +14,8 @@
 namespace grid_map_visualization
 {
 
-PointCloudVisualization::PointCloudVisualization(
-  rclcpp::Node::SharedPtr node,
-  const std::string & name)
-: VisualizationBase(node, name)
+PointCloudVisualization::PointCloudVisualization(const std::string & name)
+: VisualizationBase(name)
 {
 }
 
@@ -27,12 +25,14 @@ PointCloudVisualization::~PointCloudVisualization()
 
 bool PointCloudVisualization::readParameters()
 {
-  node_->declare_parameter(name_ + ".params.layer", std::string("elevation"));
-  if (!node_->get_parameter(name_ + ".params.layer", layer_)) {
+  this->declare_parameter(
+    std::string(this->get_name()) + ".params.layer",
+    std::string("elevation"));
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.layer", layer_)) {
     RCLCPP_ERROR(
-      node_->get_logger(),
+      this->get_logger(),
       "PointCloudVisualization with name '%s' did not find a 'layer' parameter.",
-      name_.c_str());
+      this->get_name());
     return false;
   }
   return true;
@@ -40,8 +40,8 @@ bool PointCloudVisualization::readParameters()
 
 bool PointCloudVisualization::initialize()
 {
-  publisher_ = node_->create_publisher<sensor_msgs::msg::PointCloud2>(
-    name_,
+  publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
+    this->get_name(),
     rclcpp::QoS(1).transient_local());
   return true;
 }
@@ -51,7 +51,7 @@ bool PointCloudVisualization::visualize(const grid_map::GridMap & map)
   if (!isActive()) {return false;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
-      node_->get_logger(),
+      this->get_logger(),
       "PointCloudVisualization::visualize: No grid map layer with name '" << layer_ <<
         "' found.");
     return false;

--- a/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
@@ -46,7 +46,7 @@ bool PointCloudVisualization::initialize()
 
 bool PointCloudVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive(name_)) {return true;}
+  if (!isActive()) {return true;}
   if (!map.exists(layer_)) {
     RCLCPP_WARN_STREAM(
       nodeHandle_->get_logger(),

--- a/grid_map_visualization/src/visualizations/VectorVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/VectorVisualization.cpp
@@ -24,9 +24,9 @@ namespace grid_map_visualization
 {
 
 VectorVisualization::VectorVisualization(
-  rclcpp::Node::SharedPtr nodeHandle,
+  rclcpp::Node::SharedPtr node,
   const std::string & name)
-: VisualizationBase(nodeHandle, name)
+: VisualizationBase(node, name)
 {
 }
 
@@ -36,16 +36,16 @@ VectorVisualization::~VectorVisualization()
 
 bool VectorVisualization::readParameters()
 {
-  nodeHandle_->declare_parameter(name_ + ".params.layer_prefix", std::string(""));
-  nodeHandle_->declare_parameter(name_ + ".params.position_layer", std::string(""));
-  nodeHandle_->declare_parameter(name_ + ".params.scale", 1.0);
-  nodeHandle_->declare_parameter(name_ + ".params.line_width", 0.003);
-  nodeHandle_->declare_parameter(name_ + ".params.color", 65280);
+  node_->declare_parameter(name_ + ".params.layer_prefix", std::string(""));
+  node_->declare_parameter(name_ + ".params.position_layer", std::string(""));
+  node_->declare_parameter(name_ + ".params.scale", 1.0);
+  node_->declare_parameter(name_ + ".params.line_width", 0.003);
+  node_->declare_parameter(name_ + ".params.color", 65280);
 
   std::string typePrefix;
-  if (!nodeHandle_->get_parameter(name_ + ".params.layer_prefix", typePrefix)) {
+  if (!node_->get_parameter(name_ + ".params.layer_prefix", typePrefix)) {
     RCLCPP_ERROR(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'layer_prefix' parameter.",
       name_.c_str());
     return false;
@@ -54,34 +54,34 @@ bool VectorVisualization::readParameters()
   types_.push_back(typePrefix + "y");
   types_.push_back(typePrefix + "z");
 
-  if (!nodeHandle_->get_parameter(name_ + ".params.position_layer", positionLayer_)) {
+  if (!node_->get_parameter(name_ + ".params.position_layer", positionLayer_)) {
     RCLCPP_ERROR(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'position_layer' parameter.",
       name_.c_str());
     return false;
   }
 
   scale_ = 1.0;
-  if (!nodeHandle_->get_parameter(name_ + ".params.scale", scale_)) {
+  if (!node_->get_parameter(name_ + ".params.scale", scale_)) {
     RCLCPP_INFO(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'scale' parameter. Using default.",
       name_.c_str());
   }
 
   lineWidth_ = 0.003;
-  if (!nodeHandle_->get_parameter(name_ + ".params.line_width", lineWidth_)) {
+  if (!node_->get_parameter(name_ + ".params.line_width", lineWidth_)) {
     RCLCPP_INFO(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'line_width' parameter. Using default.",
       name_.c_str());
   }
 
   int colorValue = 65280;  // green
-  if (!nodeHandle_->get_parameter(name_ + ".params.color", colorValue)) {
+  if (!node_->get_parameter(name_ + ".params.color", colorValue)) {
     RCLCPP_INFO(
-      nodeHandle_->get_logger(),
+      node_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'color' parameter. Using default.",
       name_.c_str());
   }
@@ -97,7 +97,7 @@ bool VectorVisualization::initialize()
   marker_.action = visualization_msgs::msg::Marker::ADD;
   marker_.type = visualization_msgs::msg::Marker::LINE_LIST;
   marker_.scale.x = lineWidth_;
-  publisher_ = nodeHandle_->create_publisher<visualization_msgs::msg::Marker>(name_, 1);
+  publisher_ = node_->create_publisher<visualization_msgs::msg::Marker>(name_, 1);
   return true;
 }
 
@@ -108,7 +108,7 @@ bool VectorVisualization::visualize(const grid_map::GridMap & map)
   for (const auto & type : types_) {
     if (!map.exists(type)) {
       RCLCPP_WARN_STREAM(
-        nodeHandle_->get_logger(),
+        node_->get_logger(),
         "VectorVisualization::visualize: No grid map layer with name '" << type << "' found.");
       return false;
     }

--- a/grid_map_visualization/src/visualizations/VectorVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/VectorVisualization.cpp
@@ -8,11 +8,11 @@
 
 #include "grid_map_visualization/visualizations/VectorVisualization.hpp"
 
-// Color conversion
-#include <grid_map_visualization/GridMapVisualizationHelpers.hpp>
-
 // Iterator
 #include <grid_map_core/iterators/GridMapIterator.hpp>
+
+// Color conversion
+#include <grid_map_visualization/GridMapVisualizationHelpers.hpp>
 
 // ROS
 #include <geometry_msgs/msg/point.hpp>
@@ -97,13 +97,15 @@ bool VectorVisualization::initialize()
   marker_.action = visualization_msgs::msg::Marker::ADD;
   marker_.type = visualization_msgs::msg::Marker::LINE_LIST;
   marker_.scale.x = lineWidth_;
-  publisher_ = node_->create_publisher<visualization_msgs::msg::Marker>(name_, 1);
+  publisher_ = node_->create_publisher<visualization_msgs::msg::Marker>(
+    name_,
+    rclcpp::QoS(1).transient_local());
   return true;
 }
 
 bool VectorVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) {return true;}
+  if (!isActive()) {return false;}
 
   for (const auto & type : types_) {
     if (!map.exists(type)) {

--- a/grid_map_visualization/src/visualizations/VectorVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/VectorVisualization.cpp
@@ -18,10 +18,13 @@
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Vector3.h>
 
-namespace grid_map_visualization {
+#include <string>
 
-VectorVisualization::VectorVisualization(ros::NodeHandle& nodeHandle, const std::string& name)
-    : VisualizationBase(nodeHandle, name)
+namespace grid_map_visualization
+{
+
+VectorVisualization::VectorVisualization(ros::NodeHandle & nodeHandle, const std::string & name)
+: VisualizationBase(nodeHandle, name)
 {
 }
 
@@ -29,13 +32,15 @@ VectorVisualization::~VectorVisualization()
 {
 }
 
-bool VectorVisualization::readParameters(XmlRpc::XmlRpcValue& config)
+bool VectorVisualization::readParameters(XmlRpc::XmlRpcValue & config)
 {
   VisualizationBase::readParameters(config);
 
   std::string typePrefix;
   if (!getParam("layer_prefix", typePrefix)) {
-    ROS_ERROR("VectorVisualization with name '%s' did not find a 'layer_prefix' parameter.", name_.c_str());
+    ROS_ERROR(
+      "VectorVisualization with name '%s' did not find a 'layer_prefix' parameter.",
+      name_.c_str());
     return false;
   }
   types_.push_back(typePrefix + "x");
@@ -43,23 +48,31 @@ bool VectorVisualization::readParameters(XmlRpc::XmlRpcValue& config)
   types_.push_back(typePrefix + "z");
 
   if (!getParam("position_layer", positionLayer_)) {
-    ROS_ERROR("VectorVisualization with name '%s' did not find a 'position_layer' parameter.", name_.c_str());
+    ROS_ERROR(
+      "VectorVisualization with name '%s' did not find a 'position_layer' parameter.",
+      name_.c_str());
     return false;
   }
 
   scale_ = 1.0;
   if (!getParam("scale", scale_)) {
-    ROS_INFO("VectorVisualization with name '%s' did not find a 'scale' parameter. Using default.", name_.c_str());
+    ROS_INFO(
+      "VectorVisualization with name '%s' did not find a 'scale' parameter. Using default.",
+      name_.c_str());
   }
 
   lineWidth_ = 0.003;
   if (!getParam("line_width", lineWidth_)) {
-    ROS_INFO("VectorVisualization with name '%s' did not find a 'line_width' parameter. Using default.", name_.c_str());
+    ROS_INFO(
+      "VectorVisualization with name '%s' did not find a 'line_width' parameter. Using default.",
+      name_.c_str());
   }
 
-  int colorValue = 65280; // green
+  int colorValue = 65280;  // green
   if (!getParam("color", colorValue)) {
-    ROS_INFO("VectorVisualization with name '%s' did not find a 'color' parameter. Using default.", name_.c_str());
+    ROS_INFO(
+      "VectorVisualization with name '%s' did not find a 'color' parameter. Using default.",
+      name_.c_str());
   }
   setColorFromColorValue(color_, colorValue, true);
 
@@ -77,14 +90,14 @@ bool VectorVisualization::initialize()
   return true;
 }
 
-bool VectorVisualization::visualize(const grid_map::GridMap& map)
+bool VectorVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) return true;
+  if (!isActive()) {return true;}
 
-  for (const auto& type : types_) {
+  for (const auto & type : types_) {
     if (!map.exists(type)) {
       ROS_WARN_STREAM(
-          "VectorVisualization::visualize: No grid map layer with name '" << type << "' found.");
+        "VectorVisualization::visualize: No grid map layer with name '" << type << "' found.");
       return false;
     }
   }
@@ -97,9 +110,8 @@ bool VectorVisualization::visualize(const grid_map::GridMap& map)
   marker_.points.clear();
   marker_.colors.clear();
 
-  for (grid_map::GridMapIterator iterator(map); !iterator.isPastEnd(); ++iterator)
-  {
-    if (!map.isValid(*iterator, positionLayer_) || !map.isValid(*iterator, types_)) continue;
+  for (grid_map::GridMapIterator iterator(map); !iterator.isPastEnd(); ++iterator) {
+    if (!map.isValid(*iterator, positionLayer_) || !map.isValid(*iterator, types_)) {continue;}
     geometry_msgs::Vector3 vector;
     vector.x = map.at(types_[0], *iterator);
     vector.y = map.at(types_[1], *iterator);
@@ -119,12 +131,11 @@ bool VectorVisualization::visualize(const grid_map::GridMap& map)
     endPoint.z = startPoint.z + scale_ * vector.z;
     marker_.points.push_back(endPoint);
 
-    marker_.colors.push_back(color_); // Each vertex needs a color.
+    marker_.colors.push_back(color_);  // Each vertex needs a color.
     marker_.colors.push_back(color_);
   }
 
   publisher_.publish(marker_);
   return true;
 }
-
-} /* namespace */
+}  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/VectorVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/VectorVisualization.cpp
@@ -23,10 +23,8 @@
 namespace grid_map_visualization
 {
 
-VectorVisualization::VectorVisualization(
-  rclcpp::Node::SharedPtr node,
-  const std::string & name)
-: VisualizationBase(node, name)
+VectorVisualization::VectorVisualization(const std::string & name)
+: VisualizationBase(name)
 {
 }
 
@@ -36,54 +34,59 @@ VectorVisualization::~VectorVisualization()
 
 bool VectorVisualization::readParameters()
 {
-  node_->declare_parameter(name_ + ".params.layer_prefix", std::string(""));
-  node_->declare_parameter(name_ + ".params.position_layer", std::string(""));
-  node_->declare_parameter(name_ + ".params.scale", 1.0);
-  node_->declare_parameter(name_ + ".params.line_width", 0.003);
-  node_->declare_parameter(name_ + ".params.color", 65280);
+  this->declare_parameter(std::string(this->get_name()) + ".params.layer_prefix", std::string(""));
+  this->declare_parameter(
+    std::string(this->get_name()) + ".params.position_layer",
+    std::string(""));
+  this->declare_parameter(std::string(this->get_name()) + ".params.scale", 1.0);
+  this->declare_parameter(std::string(this->get_name()) + ".params.line_width", 0.003);
+  this->declare_parameter(std::string(this->get_name()) + ".params.color", 65280);
 
   std::string typePrefix;
-  if (!node_->get_parameter(name_ + ".params.layer_prefix", typePrefix)) {
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.layer_prefix", typePrefix)) {
     RCLCPP_ERROR(
-      node_->get_logger(),
+      this->get_logger(),
       "VectorVisualization with name '%s' did not find a 'layer_prefix' parameter.",
-      name_.c_str());
+      this->get_name());
     return false;
   }
   types_.push_back(typePrefix + "x");
   types_.push_back(typePrefix + "y");
   types_.push_back(typePrefix + "z");
 
-  if (!node_->get_parameter(name_ + ".params.position_layer", positionLayer_)) {
+  if (!this->get_parameter(
+      std::string(this->get_name()) + ".params.position_layer",
+      positionLayer_))
+  {
     RCLCPP_ERROR(
-      node_->get_logger(),
+      this->get_logger(),
       "VectorVisualization with name '%s' did not find a 'position_layer' parameter.",
-      name_.c_str());
+      this->get_name());
     return false;
   }
 
   scale_ = 1.0;
-  if (!node_->get_parameter(name_ + ".params.scale", scale_)) {
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.scale", scale_)) {
     RCLCPP_INFO(
-      node_->get_logger(),
+      this->get_logger(),
       "VectorVisualization with name '%s' did not find a 'scale' parameter. Using default.",
-      name_.c_str());
+      this->get_name());
   }
 
   lineWidth_ = 0.003;
-  if (!node_->get_parameter(name_ + ".params.line_width", lineWidth_)) {
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.line_width", lineWidth_)) {
     RCLCPP_INFO(
-      node_->get_logger(),
+      this->get_logger(),
       "VectorVisualization with name '%s' did not find a 'line_width' parameter. Using default.",
-      name_.c_str());
+      this->get_name());
   }
 
   int colorValue = 65280;  // green
-  if (!node_->get_parameter(name_ + ".params.color", colorValue)) {
+  if (!this->get_parameter(std::string(this->get_name()) + ".params.color", colorValue)) {
     RCLCPP_INFO(
-      node_->get_logger(),
+      this->get_logger(),
       "VectorVisualization with name '%s' did not find a 'color' parameter. Using default.",
-      name_.c_str());
+      this->get_name());
   }
   setColorFromColorValue(color_, colorValue, true);
 
@@ -97,8 +100,8 @@ bool VectorVisualization::initialize()
   marker_.action = visualization_msgs::msg::Marker::ADD;
   marker_.type = visualization_msgs::msg::Marker::LINE_LIST;
   marker_.scale.x = lineWidth_;
-  publisher_ = node_->create_publisher<visualization_msgs::msg::Marker>(
-    name_,
+  publisher_ = this->create_publisher<visualization_msgs::msg::Marker>(
+    this->get_name(),
     rclcpp::QoS(1).transient_local());
   return true;
 }
@@ -110,7 +113,7 @@ bool VectorVisualization::visualize(const grid_map::GridMap & map)
   for (const auto & type : types_) {
     if (!map.exists(type)) {
       RCLCPP_WARN_STREAM(
-        node_->get_logger(),
+        this->get_logger(),
         "VectorVisualization::visualize: No grid map layer with name '" << type << "' found.");
       return false;
     }

--- a/grid_map_visualization/src/visualizations/VectorVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/VectorVisualization.cpp
@@ -15,15 +15,17 @@
 #include <grid_map_core/iterators/GridMapIterator.hpp>
 
 // ROS
-#include <geometry_msgs/Point.h>
-#include <geometry_msgs/Vector3.h>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
 
 #include <string>
 
 namespace grid_map_visualization
 {
 
-VectorVisualization::VectorVisualization(ros::NodeHandle & nodeHandle, const std::string & name)
+VectorVisualization::VectorVisualization(
+  rclcpp::Node::SharedPtr nodeHandle,
+  const std::string & name)
 : VisualizationBase(nodeHandle, name)
 {
 }
@@ -32,13 +34,12 @@ VectorVisualization::~VectorVisualization()
 {
 }
 
-bool VectorVisualization::readParameters(XmlRpc::XmlRpcValue & config)
+bool VectorVisualization::readParameters()
 {
-  VisualizationBase::readParameters(config);
-
   std::string typePrefix;
-  if (!getParam("layer_prefix", typePrefix)) {
-    ROS_ERROR(
+  if (!nodeHandle_->get_parameter(name_ + "layer_prefix", typePrefix)) {
+    RCLCPP_ERROR(
+      nodeHandle_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'layer_prefix' parameter.",
       name_.c_str());
     return false;
@@ -47,30 +48,34 @@ bool VectorVisualization::readParameters(XmlRpc::XmlRpcValue & config)
   types_.push_back(typePrefix + "y");
   types_.push_back(typePrefix + "z");
 
-  if (!getParam("position_layer", positionLayer_)) {
-    ROS_ERROR(
+  if (!nodeHandle_->get_parameter(name_ + "position_layer", positionLayer_)) {
+    RCLCPP_ERROR(
+      nodeHandle_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'position_layer' parameter.",
       name_.c_str());
     return false;
   }
 
   scale_ = 1.0;
-  if (!getParam("scale", scale_)) {
-    ROS_INFO(
+  if (!nodeHandle_->get_parameter(name_ + "scale", scale_)) {
+    RCLCPP_INFO(
+      nodeHandle_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'scale' parameter. Using default.",
       name_.c_str());
   }
 
   lineWidth_ = 0.003;
-  if (!getParam("line_width", lineWidth_)) {
-    ROS_INFO(
+  if (!nodeHandle_->get_parameter(name_ + "line_width", lineWidth_)) {
+    RCLCPP_INFO(
+      nodeHandle_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'line_width' parameter. Using default.",
       name_.c_str());
   }
 
   int colorValue = 65280;  // green
-  if (!getParam("color", colorValue)) {
-    ROS_INFO(
+  if (!nodeHandle_->get_parameter(name_ + "color", colorValue)) {
+    RCLCPP_INFO(
+      nodeHandle_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'color' parameter. Using default.",
       name_.c_str());
   }
@@ -82,21 +87,22 @@ bool VectorVisualization::readParameters(XmlRpc::XmlRpcValue & config)
 bool VectorVisualization::initialize()
 {
   marker_.ns = "vector";
-  marker_.lifetime = ros::Duration();
-  marker_.action = visualization_msgs::Marker::ADD;
-  marker_.type = visualization_msgs::Marker::LINE_LIST;
+  marker_.lifetime = rclcpp::Duration(0);  // setting lifetime forever
+  marker_.action = visualization_msgs::msg::Marker::ADD;
+  marker_.type = visualization_msgs::msg::Marker::LINE_LIST;
   marker_.scale.x = lineWidth_;
-  publisher_ = nodeHandle_.advertise<visualization_msgs::Marker>(name_, 1, true);
+  publisher_ = nodeHandle_->create_publisher<visualization_msgs::msg::Marker>(name_, 10);
   return true;
 }
 
 bool VectorVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive()) {return true;}
+  if (!isActive(name_)) {return true;}
 
   for (const auto & type : types_) {
     if (!map.exists(type)) {
-      ROS_WARN_STREAM(
+      RCLCPP_WARN_STREAM(
+        nodeHandle_->get_logger(),
         "VectorVisualization::visualize: No grid map layer with name '" << type << "' found.");
       return false;
     }
@@ -104,7 +110,7 @@ bool VectorVisualization::visualize(const grid_map::GridMap & map)
 
   // Set marker info.
   marker_.header.frame_id = map.getFrameId();
-  marker_.header.stamp.fromNSec(map.getTimestamp());
+  marker_.header.stamp = rclcpp::Time(map.getTimestamp());
 
   // Clear points.
   marker_.points.clear();
@@ -112,20 +118,20 @@ bool VectorVisualization::visualize(const grid_map::GridMap & map)
 
   for (grid_map::GridMapIterator iterator(map); !iterator.isPastEnd(); ++iterator) {
     if (!map.isValid(*iterator, positionLayer_) || !map.isValid(*iterator, types_)) {continue;}
-    geometry_msgs::Vector3 vector;
+    geometry_msgs::msg::Vector3 vector;
     vector.x = map.at(types_[0], *iterator);
     vector.y = map.at(types_[1], *iterator);
     vector.z = map.at(types_[2], *iterator);
 
     Eigen::Vector3d position;
     map.getPosition3(positionLayer_, *iterator, position);
-    geometry_msgs::Point startPoint;
+    geometry_msgs::msg::Point startPoint;
     startPoint.x = position.x();
     startPoint.y = position.y();
     startPoint.z = position.z();
     marker_.points.push_back(startPoint);
 
-    geometry_msgs::Point endPoint;
+    geometry_msgs::msg::Point endPoint;
     endPoint.x = startPoint.x + scale_ * vector.x;
     endPoint.y = startPoint.y + scale_ * vector.y;
     endPoint.z = startPoint.z + scale_ * vector.z;
@@ -135,7 +141,7 @@ bool VectorVisualization::visualize(const grid_map::GridMap & map)
     marker_.colors.push_back(color_);
   }
 
-  publisher_.publish(marker_);
+  publisher_->publish(marker_);
   return true;
 }
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/VectorVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/VectorVisualization.cpp
@@ -36,8 +36,14 @@ VectorVisualization::~VectorVisualization()
 
 bool VectorVisualization::readParameters()
 {
+  nodeHandle_->declare_parameter(name_ + ".params.layer_prefix", std::string(""));
+  nodeHandle_->declare_parameter(name_ + ".params.position_layer", std::string(""));
+  nodeHandle_->declare_parameter(name_ + ".params.scale", 1.0);
+  nodeHandle_->declare_parameter(name_ + ".params.line_width", 0.003);
+  nodeHandle_->declare_parameter(name_ + ".params.color", 65280);
+
   std::string typePrefix;
-  if (!nodeHandle_->get_parameter(name_ + "layer_prefix", typePrefix)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.layer_prefix", typePrefix)) {
     RCLCPP_ERROR(
       nodeHandle_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'layer_prefix' parameter.",
@@ -48,7 +54,7 @@ bool VectorVisualization::readParameters()
   types_.push_back(typePrefix + "y");
   types_.push_back(typePrefix + "z");
 
-  if (!nodeHandle_->get_parameter(name_ + "position_layer", positionLayer_)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.position_layer", positionLayer_)) {
     RCLCPP_ERROR(
       nodeHandle_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'position_layer' parameter.",
@@ -57,7 +63,7 @@ bool VectorVisualization::readParameters()
   }
 
   scale_ = 1.0;
-  if (!nodeHandle_->get_parameter(name_ + "scale", scale_)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.scale", scale_)) {
     RCLCPP_INFO(
       nodeHandle_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'scale' parameter. Using default.",
@@ -65,7 +71,7 @@ bool VectorVisualization::readParameters()
   }
 
   lineWidth_ = 0.003;
-  if (!nodeHandle_->get_parameter(name_ + "line_width", lineWidth_)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.line_width", lineWidth_)) {
     RCLCPP_INFO(
       nodeHandle_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'line_width' parameter. Using default.",
@@ -73,7 +79,7 @@ bool VectorVisualization::readParameters()
   }
 
   int colorValue = 65280;  // green
-  if (!nodeHandle_->get_parameter(name_ + "color", colorValue)) {
+  if (!nodeHandle_->get_parameter(name_ + ".params.color", colorValue)) {
     RCLCPP_INFO(
       nodeHandle_->get_logger(),
       "VectorVisualization with name '%s' did not find a 'color' parameter. Using default.",
@@ -91,7 +97,7 @@ bool VectorVisualization::initialize()
   marker_.action = visualization_msgs::msg::Marker::ADD;
   marker_.type = visualization_msgs::msg::Marker::LINE_LIST;
   marker_.scale.x = lineWidth_;
-  publisher_ = nodeHandle_->create_publisher<visualization_msgs::msg::Marker>(name_, 10);
+  publisher_ = nodeHandle_->create_publisher<visualization_msgs::msg::Marker>(name_, 1);
   return true;
 }
 

--- a/grid_map_visualization/src/visualizations/VectorVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/VectorVisualization.cpp
@@ -103,7 +103,7 @@ bool VectorVisualization::initialize()
 
 bool VectorVisualization::visualize(const grid_map::GridMap & map)
 {
-  if (!isActive(name_)) {return true;}
+  if (!isActive()) {return true;}
 
   for (const auto & type : types_) {
     if (!map.exists(type)) {

--- a/grid_map_visualization/src/visualizations/VisualizationBase.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationBase.cpp
@@ -13,7 +13,7 @@
 namespace grid_map_visualization
 {
 
-VisualizationBase::VisualizationBase(ros::NodeHandle & nodeHandle, const std::string & name)
+VisualizationBase::VisualizationBase(rclcpp::Node::SharedPtr nodeHandle, const std::string & name)
 : nodeHandle_(nodeHandle),
   name_(name)
 {
@@ -23,80 +23,9 @@ VisualizationBase::~VisualizationBase()
 {
 }
 
-bool VisualizationBase::isActive() const
+bool VisualizationBase::isActive(const std::string & topic) const
 {
-  if (publisher_.getNumSubscribers() > 0) {return true;}
+  if (nodeHandle_->count_subscribers(topic) > 0) {return true;}
   return false;
 }
-
-bool VisualizationBase::readParameters(XmlRpc::XmlRpcValue & config)
-{
-  if (config.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
-    ROS_ERROR("A filter configuration must be a map with fields name, type, and params.");
-    return false;
-  }
-
-  // Check to see if we have parameters in our list.
-  if (config.hasMember("params")) {
-    XmlRpc::XmlRpcValue params = config["params"];
-    if (params.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
-      ROS_ERROR("Params must be a map.");
-      return false;
-    } else {
-      for (XmlRpc::XmlRpcValue::iterator it = params.begin(); it != params.end(); ++it) {
-        ROS_DEBUG("Loading param %s\n", it->first.c_str());
-        parameters_[it->first] = it->second;
-      }
-    }
-  }
-
-  return true;
-}
-
-bool VisualizationBase::getParam(const std::string & name, std::string & value)
-{
-  StringMap::iterator it = parameters_.find(name);
-  if (it == parameters_.end()) {return false;}
-  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeString) {return false;}
-  value = std::string(it->second);
-  return true;
-}
-
-bool VisualizationBase::getParam(const std::string & name, double & value)
-{
-  StringMap::iterator it = parameters_.find(name);
-  if (it == parameters_.end()) {return false;}
-  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeDouble &&
-    it->second.getType() != XmlRpc::XmlRpcValue::TypeInt) {return false;}
-  value = it->second.getType() == XmlRpc::XmlRpcValue::TypeInt ?
-    static_cast<int>(it->second) : static_cast<double>(it->second);
-  return true;
-}
-
-bool VisualizationBase::getParam(const std::string & name, float & value)
-{
-  double valueDouble;
-  bool isSuccess = getParam(name, valueDouble);
-  if (isSuccess) {value = static_cast<float>(valueDouble);}
-  return isSuccess;
-}
-
-bool VisualizationBase::getParam(const std::string & name, bool & value)
-{
-  StringMap::iterator it = parameters_.find(name);
-  if (it == parameters_.end()) {return false;}
-  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeBoolean) {return false;}
-  value = it->second;
-  return true;
-}
-
-bool VisualizationBase::getParam(const std::string & name, int & value)
-{
-  StringMap::iterator it = parameters_.find(name);
-  if (it == parameters_.end()) {return false;}
-  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeInt) {return false;}
-  value = it->second;
-  return true;
-}
-
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/VisualizationBase.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationBase.cpp
@@ -8,11 +8,14 @@
 
 #include "grid_map_visualization/visualizations/VisualizationBase.hpp"
 
-namespace grid_map_visualization {
+#include <string>
 
-VisualizationBase::VisualizationBase(ros::NodeHandle& nodeHandle, const std::string& name)
-    : nodeHandle_(nodeHandle),
-      name_(name)
+namespace grid_map_visualization
+{
+
+VisualizationBase::VisualizationBase(ros::NodeHandle & nodeHandle, const std::string & name)
+: nodeHandle_(nodeHandle),
+  name_(name)
 {
 }
 
@@ -22,11 +25,11 @@ VisualizationBase::~VisualizationBase()
 
 bool VisualizationBase::isActive() const
 {
-  if (publisher_.getNumSubscribers() > 0) return true;
+  if (publisher_.getNumSubscribers() > 0) {return true;}
   return false;
 }
 
-bool VisualizationBase::readParameters(XmlRpc::XmlRpcValue& config)
+bool VisualizationBase::readParameters(XmlRpc::XmlRpcValue & config)
 {
   if (config.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
     ROS_ERROR("A filter configuration must be a map with fields name, type, and params.");
@@ -50,50 +53,50 @@ bool VisualizationBase::readParameters(XmlRpc::XmlRpcValue& config)
   return true;
 }
 
-bool VisualizationBase::getParam(const std::string& name, std::string& value)
+bool VisualizationBase::getParam(const std::string & name, std::string & value)
 {
   StringMap::iterator it = parameters_.find(name);
-  if (it == parameters_.end()) return false;
-  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeString) return false;
+  if (it == parameters_.end()) {return false;}
+  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeString) {return false;}
   value = std::string(it->second);
   return true;
 }
 
-bool VisualizationBase::getParam(const std::string& name, double& value)
+bool VisualizationBase::getParam(const std::string & name, double & value)
 {
   StringMap::iterator it = parameters_.find(name);
-  if (it == parameters_.end()) return false;
-  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeDouble
-      && it->second.getType() != XmlRpc::XmlRpcValue::TypeInt) return false;
+  if (it == parameters_.end()) {return false;}
+  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeDouble &&
+    it->second.getType() != XmlRpc::XmlRpcValue::TypeInt) {return false;}
   value = it->second.getType() == XmlRpc::XmlRpcValue::TypeInt ?
-          (int) (it->second) : (double) (it->second);
+    static_cast<int>(it->second) : static_cast<double>(it->second);
   return true;
 }
 
-bool VisualizationBase::getParam(const std::string& name, float& value)
+bool VisualizationBase::getParam(const std::string & name, float & value)
 {
   double valueDouble;
   bool isSuccess = getParam(name, valueDouble);
-  if (isSuccess) value = static_cast<float>(valueDouble);
+  if (isSuccess) {value = static_cast<float>(valueDouble);}
   return isSuccess;
 }
 
-bool VisualizationBase::getParam(const std::string& name, bool& value)
+bool VisualizationBase::getParam(const std::string & name, bool & value)
 {
   StringMap::iterator it = parameters_.find(name);
-  if (it == parameters_.end()) return false;
-  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeBoolean) return false;
+  if (it == parameters_.end()) {return false;}
+  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeBoolean) {return false;}
   value = it->second;
   return true;
 }
 
-bool VisualizationBase::getParam(const std::string&name, int& value)
+bool VisualizationBase::getParam(const std::string & name, int & value)
 {
   StringMap::iterator it = parameters_.find(name);
-  if (it == parameters_.end()) return false;
-  if(it->second.getType() != XmlRpc::XmlRpcValue::TypeInt) return false;
+  if (it == parameters_.end()) {return false;}
+  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeInt) {return false;}
   value = it->second;
   return true;
 }
 
-} /* namespace */
+}  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/VisualizationBase.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationBase.cpp
@@ -13,9 +13,8 @@
 namespace grid_map_visualization
 {
 
-VisualizationBase::VisualizationBase(rclcpp::Node::SharedPtr node, const std::string & name)
-: node_(node),
-  name_(name)
+VisualizationBase::VisualizationBase(const std::string & name)
+: Node(name)
 {
 }
 
@@ -25,6 +24,6 @@ VisualizationBase::~VisualizationBase()
 
 bool VisualizationBase::isActive() const
 {
-  return static_cast<bool>(node_->count_subscribers(name_));
+  return static_cast<bool>(this->count_subscribers(this->get_name()));
 }
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/VisualizationBase.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationBase.cpp
@@ -23,9 +23,9 @@ VisualizationBase::~VisualizationBase()
 {
 }
 
-bool VisualizationBase::isActive(const std::string & topic) const
+bool VisualizationBase::isActive() const
 {
-  if (nodeHandle_->count_subscribers(topic) > 0) {return true;}
+  if (nodeHandle_->count_subscribers(name_) > 0) {return true;}
   return false;
 }
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/VisualizationBase.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationBase.cpp
@@ -13,8 +13,8 @@
 namespace grid_map_visualization
 {
 
-VisualizationBase::VisualizationBase(rclcpp::Node::SharedPtr nodeHandle, const std::string & name)
-: nodeHandle_(nodeHandle),
+VisualizationBase::VisualizationBase(rclcpp::Node::SharedPtr node, const std::string & name)
+: node_(node),
   name_(name)
 {
 }
@@ -25,7 +25,7 @@ VisualizationBase::~VisualizationBase()
 
 bool VisualizationBase::isActive() const
 {
-  if (nodeHandle_->count_subscribers(name_) > 0) {return true;}
+  if (node_->count_subscribers(name_) > 0) {return true;}
   return false;
 }
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/VisualizationBase.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationBase.cpp
@@ -25,7 +25,6 @@ VisualizationBase::~VisualizationBase()
 
 bool VisualizationBase::isActive() const
 {
-  if (node_->count_subscribers(name_) > 0) {return true;}
-  return false;
+  return static_cast<bool>(node_->count_subscribers(name_));
 }
 }  // namespace grid_map_visualization

--- a/grid_map_visualization/src/visualizations/VisualizationFactory.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationFactory.cpp
@@ -6,23 +6,23 @@
  *   Institute: ETH Zurich, ANYbotics
  */
 
-#include <grid_map_visualization/visualizations/VisualizationFactory.hpp>
-#include <grid_map_visualization/visualizations/PointCloudVisualization.hpp>
-#include <grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp>
-#include <grid_map_visualization/visualizations/VectorVisualization.hpp>
-#include <grid_map_visualization/visualizations/OccupancyGridVisualization.hpp>
-#include <grid_map_visualization/visualizations/GridCellsVisualization.hpp>
-#include <grid_map_visualization/visualizations/MapRegionVisualization.hpp>
-
 // STL
 #include <string>
 #include <memory>
 #include <algorithm>
 
+#include "grid_map_visualization/visualizations/VisualizationFactory.hpp"
+#include "grid_map_visualization/visualizations/PointCloudVisualization.hpp"
+#include "grid_map_visualization/visualizations/FlatPointCloudVisualization.hpp"
+#include "grid_map_visualization/visualizations/VectorVisualization.hpp"
+#include "grid_map_visualization/visualizations/OccupancyGridVisualization.hpp"
+#include "grid_map_visualization/visualizations/GridCellsVisualization.hpp"
+#include "grid_map_visualization/visualizations/MapRegionVisualization.hpp"
+
 namespace grid_map_visualization
 {
 
-VisualizationFactory::VisualizationFactory(ros::NodeHandle & nodeHandle)
+VisualizationFactory::VisualizationFactory(rclcpp::Node::SharedPtr nodeHandle)
 : nodeHandle_(nodeHandle)
 {
   types_.push_back("point_cloud");

--- a/grid_map_visualization/src/visualizations/VisualizationFactory.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationFactory.cpp
@@ -22,8 +22,8 @@
 namespace grid_map_visualization
 {
 
-VisualizationFactory::VisualizationFactory(rclcpp::Node::SharedPtr nodeHandle)
-: nodeHandle_(nodeHandle)
+VisualizationFactory::VisualizationFactory(rclcpp::Node::SharedPtr node)
+: node_(node)
 {
   types_.push_back("point_cloud");
   types_.push_back("flat_point_cloud");
@@ -49,22 +49,22 @@ std::shared_ptr<VisualizationBase> VisualizationFactory::getInstance(
   // TODO(needs_assignment):
   // Make this nicer: http://stackoverflow.com/questions/9975672/c-automatic-factory-registration-of-derived-types
   if (type == "point_cloud") {
-    return std::shared_ptr<VisualizationBase>(new PointCloudVisualization(nodeHandle_, name));
+    return std::shared_ptr<VisualizationBase>(new PointCloudVisualization(node_, name));
   }
   if (type == "flat_point_cloud") {
-    return std::shared_ptr<VisualizationBase>(new FlatPointCloudVisualization(nodeHandle_, name));
+    return std::shared_ptr<VisualizationBase>(new FlatPointCloudVisualization(node_, name));
   }
   if (type == "vectors") {
-    return std::shared_ptr<VisualizationBase>(new VectorVisualization(nodeHandle_, name));
+    return std::shared_ptr<VisualizationBase>(new VectorVisualization(node_, name));
   }
   if (type == "occupancy_grid") {
-    return std::shared_ptr<VisualizationBase>(new OccupancyGridVisualization(nodeHandle_, name));
+    return std::shared_ptr<VisualizationBase>(new OccupancyGridVisualization(node_, name));
   }
   if (type == "grid_cells") {
-    return std::shared_ptr<VisualizationBase>(new GridCellsVisualization(nodeHandle_, name));
+    return std::shared_ptr<VisualizationBase>(new GridCellsVisualization(node_, name));
   }
   if (type == "map_region") {
-    return std::shared_ptr<VisualizationBase>(new MapRegionVisualization(nodeHandle_, name));
+    return std::shared_ptr<VisualizationBase>(new MapRegionVisualization(node_, name));
   }
   return std::shared_ptr<VisualizationBase>();
 }

--- a/grid_map_visualization/src/visualizations/VisualizationFactory.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationFactory.cpp
@@ -22,8 +22,7 @@
 namespace grid_map_visualization
 {
 
-VisualizationFactory::VisualizationFactory(rclcpp::Node::SharedPtr node)
-: node_(node)
+VisualizationFactory::VisualizationFactory()
 {
   types_.push_back("point_cloud");
   types_.push_back("flat_point_cloud");
@@ -49,22 +48,22 @@ std::shared_ptr<VisualizationBase> VisualizationFactory::getInstance(
   // TODO(needs_assignment):
   // Make this nicer: http://stackoverflow.com/questions/9975672/c-automatic-factory-registration-of-derived-types
   if (type == "point_cloud") {
-    return std::shared_ptr<VisualizationBase>(new PointCloudVisualization(node_, name));
+    return std::shared_ptr<VisualizationBase>(new PointCloudVisualization(name));
   }
   if (type == "flat_point_cloud") {
-    return std::shared_ptr<VisualizationBase>(new FlatPointCloudVisualization(node_, name));
+    return std::shared_ptr<VisualizationBase>(new FlatPointCloudVisualization(name));
   }
   if (type == "vectors") {
-    return std::shared_ptr<VisualizationBase>(new VectorVisualization(node_, name));
+    return std::shared_ptr<VisualizationBase>(new VectorVisualization(name));
   }
   if (type == "occupancy_grid") {
-    return std::shared_ptr<VisualizationBase>(new OccupancyGridVisualization(node_, name));
+    return std::shared_ptr<VisualizationBase>(new OccupancyGridVisualization(name));
   }
   if (type == "grid_cells") {
-    return std::shared_ptr<VisualizationBase>(new GridCellsVisualization(node_, name));
+    return std::shared_ptr<VisualizationBase>(new GridCellsVisualization(name));
   }
   if (type == "map_region") {
-    return std::shared_ptr<VisualizationBase>(new MapRegionVisualization(node_, name));
+    return std::shared_ptr<VisualizationBase>(new MapRegionVisualization(name));
   }
   return std::shared_ptr<VisualizationBase>();
 }

--- a/grid_map_visualization/src/visualizations/VisualizationFactory.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationFactory.cpp
@@ -7,9 +7,9 @@
  */
 
 // STL
-#include <string>
-#include <memory>
 #include <algorithm>
+#include <memory>
+#include <string>
 
 #include "grid_map_visualization/visualizations/VisualizationFactory.hpp"
 #include "grid_map_visualization/visualizations/PointCloudVisualization.hpp"

--- a/grid_map_visualization/src/visualizations/VisualizationFactory.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationFactory.cpp
@@ -15,12 +15,15 @@
 #include <grid_map_visualization/visualizations/MapRegionVisualization.hpp>
 
 // STL
+#include <string>
+#include <memory>
 #include <algorithm>
 
-namespace grid_map_visualization {
+namespace grid_map_visualization
+{
 
-VisualizationFactory::VisualizationFactory(ros::NodeHandle& nodeHandle)
-    : nodeHandle_(nodeHandle)
+VisualizationFactory::VisualizationFactory(ros::NodeHandle & nodeHandle)
+: nodeHandle_(nodeHandle)
 {
   types_.push_back("point_cloud");
   types_.push_back("flat_point_cloud");
@@ -34,22 +37,36 @@ VisualizationFactory::~VisualizationFactory()
 {
 }
 
-bool VisualizationFactory::isValidType(const std::string& type)
+bool VisualizationFactory::isValidType(const std::string & type)
 {
   return end(types_) != std::find(begin(types_), end(types_), type);
 }
 
-std::shared_ptr<VisualizationBase> VisualizationFactory::getInstance(const std::string& type,
-                                                                     const std::string& name)
+std::shared_ptr<VisualizationBase> VisualizationFactory::getInstance(
+  const std::string & type,
+  const std::string & name)
 {
-  // TODO: Make this nicer: http://stackoverflow.com/questions/9975672/c-automatic-factory-registration-of-derived-types
-  if (type == "point_cloud") return std::shared_ptr<VisualizationBase>(new PointCloudVisualization(nodeHandle_, name));
-  if (type == "flat_point_cloud") return std::shared_ptr<VisualizationBase>(new FlatPointCloudVisualization(nodeHandle_, name));
-  if (type == "vectors") return std::shared_ptr<VisualizationBase>(new VectorVisualization(nodeHandle_, name));
-  if (type == "occupancy_grid") return std::shared_ptr<VisualizationBase>(new OccupancyGridVisualization(nodeHandle_, name));
-  if (type == "grid_cells") return std::shared_ptr<VisualizationBase>(new GridCellsVisualization(nodeHandle_, name));
-  if (type == "map_region") return std::shared_ptr<VisualizationBase>(new MapRegionVisualization(nodeHandle_, name));
+  // TODO(needs_assignment):
+  // Make this nicer: http://stackoverflow.com/questions/9975672/c-automatic-factory-registration-of-derived-types
+  if (type == "point_cloud") {
+    return std::shared_ptr<VisualizationBase>(new PointCloudVisualization(nodeHandle_, name));
+  }
+  if (type == "flat_point_cloud") {
+    return std::shared_ptr<VisualizationBase>(new FlatPointCloudVisualization(nodeHandle_, name));
+  }
+  if (type == "vectors") {
+    return std::shared_ptr<VisualizationBase>(new VectorVisualization(nodeHandle_, name));
+  }
+  if (type == "occupancy_grid") {
+    return std::shared_ptr<VisualizationBase>(new OccupancyGridVisualization(nodeHandle_, name));
+  }
+  if (type == "grid_cells") {
+    return std::shared_ptr<VisualizationBase>(new GridCellsVisualization(nodeHandle_, name));
+  }
+  if (type == "map_region") {
+    return std::shared_ptr<VisualizationBase>(new MapRegionVisualization(nodeHandle_, name));
+  }
   return std::shared_ptr<VisualizationBase>();
 }
 
-} /* namespace grid_map_visualization */
+}  // namespace grid_map_visualization

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   ros-planning/navigation2:
     type: git
     url: https://github.com/ros-planning/navigation2.git
-    version: master
+    version: main
 
   ros2/rcpputils:
     type: git


### PR DESCRIPTION
Changes:
- Unsubscribing from topics is not available atm in rclcpp (according to [this](https://answers.ros.org/question/354792/rclcpp-how-to-unsubscribe-from-a-topic/)), so the subscription updating functionality in `GridMapVisualization` has been disabled for now.
- The parameters handled API in ROS2 is slightly different and so the parameters have been slightly modified, example:
  From this:

    ```
    grid_map_visualizations:
      - name: elevation_points
          type: point_cloud
          params:
            layer: elevation
      - name: elevation_grid
          type: occupancy_grid
          params:
            layer: elevation
            data_min: 0.08
            data_max: -0.16
    ```

    To this:
    ```
    grid_map_visualization:
        ros__parameters:
            grid_map_topic: /grid_map_simple_demo/grid_map
            grid_map_visualizations: [elevation_points, elevation_grid]
            elevation_points:
                type: point_cloud
                params:
                    layer: elevation
            elevation_grid:
                type: occupancy_grid
                params:
                    layer: elevation
                    data_min: 0.08
                    data_max: -0.16
    ```
  Is that okay??
- Since [rclcpp::publisher](http://docs.ros2.org/foxy/api/rclcpp/classrclcpp_1_1Publisher.html) is a template, I have moved the publisher to live in the visualisation derived classes instead of having it in the `VisualizationBase` class.