### PR TITLE
Fix CI for ROS2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             cd $UNDERLAY_WS && vcs import src < ros2_dependencies.repos
             DEBIAN_FRONTEND=noninteractive  rosdep install -y --ignore-src --from-paths src
             colcon build --symlink-install --parallel-workers 1 --packages-up-to \
-              rcpputils rosbag2_cpp pcl_ros
+              pcl_ros
             source $UNDERLAY_WS/install/setup.bash
             cd $OVERLAY_WS && rosdep install -y --ignore-src --from-paths src
       - run:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Clone and build grid_map ROS2 dependencies.
     wget https://raw.githubusercontent.com/ANYbotics/grid_map/ros2/tools/ros2_dependencies.repos
     vcs import src < ros2_dependencies.repos
     rosdep install -y --ignore-src --from-paths src
-    colcon build --symlink-install --packages-up-to rcpputils rosbag2_cpp pcl_ros
+    colcon build --symlink-install --packages-up-to pcl_ros
 
 The other packages depend additionally on the [ROS] standard installation (*rclcpp*, *tf*, *filters*, *sensor_msgs*, *nav_msgs*, and *cv_bridge*). Other format specific conversion packages (e.g. *grid_map_cv*, *grid_map_pcl* etc.) depend on packages described below in *Packages Overview*.
 

--- a/grid_map_ros/test/GridMapRosTest.cpp
+++ b/grid_map_ros/test/GridMapRosTest.cpp
@@ -79,6 +79,7 @@ TEST(RosbagHandling, saveLoad)
   // Cleaning in case the previous bag was not removed
   rcpputils::fs::path dir(pathToBag);
   rcpputils::fs::remove_all(dir);
+  rcpputils::fs::create_directories(dir);
 
   EXPECT_TRUE(GridMapRosConverter::saveToBag(gridMapIn, pathToBag, topic));
   EXPECT_TRUE(GridMapRosConverter::loadFromBag(pathToBag, topic, gridMapOut));
@@ -116,6 +117,7 @@ TEST(RosbagHandling, saveLoadWithTime)
   // Cleaning in case the previous bag was not removed
   rcpputils::fs::path dir(pathToBag);
   rcpputils::fs::remove_all(dir);
+  rcpputils::fs::create_directories(dir);
 
   EXPECT_TRUE(GridMapRosConverter::saveToBag(gridMapIn, pathToBag, topic));
   EXPECT_TRUE(GridMapRosConverter::loadFromBag(pathToBag, topic, gridMapOut));

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -1,20 +1,5 @@
 repositories:
-  ros2/rcpputils:
-    type: git
-    url: https://github.com/ros2/rcpputils.git
-    version: master
-
-  ros2/rosbag2:
-    type: git
-    url: https://github.com/ros2/rosbag2.git
-    version: master
-
   ros-perception/perception_pcl:
     type: git
     url: https://github.com/ros-perception/perception_pcl.git
     version: foxy-devel
-
-  ros-perception/pcl_msgs:
-    type: git
-    url: https://github.com/ros-perception/pcl_msgs.git
-    version: ros2


### PR DESCRIPTION
This fixes CI failure for ros2 branch.

Changes made:
* removed unnecessary dependencies in repos file (rcpputils, rosbag2, pcl_msgs can be installed by rosdep)
* fixed test failure in grid_map_ros package