### PR TITLE
Switch header path from hpp to h for filter_base

### DIFF
--- a/grid_map_cv/include/grid_map_cv/InpaintFilter.hpp
+++ b/grid_map_cv/include/grid_map_cv/InpaintFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 //OpenCV
 #include "grid_map_cv/grid_map_cv.hpp"

--- a/grid_map_demos/include/grid_map_demos/FiltersDemo.hpp
+++ b/grid_map_demos/include/grid_map_demos/FiltersDemo.hpp
@@ -14,7 +14,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #pragma GCC diagnostic ignored "-Wformat"
-#include <filters/filter_chain.hpp>
+#include <filters/filter_chain.h>
 #pragma GCC diagnostic pop
 #include <ros/ros.h>
 #include <string>

--- a/grid_map_demos/src/normal_filter_comparison_node.cpp
+++ b/grid_map_demos/src/normal_filter_comparison_node.cpp
@@ -7,7 +7,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #pragma GCC diagnostic ignored "-Wformat"
-#include <filters/filter_chain.hpp>
+#include <filters/filter_chain.h>
 #pragma GCC diagnostic pop
 #include <ros/ros.h>
 #include <Eigen/Core>

--- a/grid_map_filters/include/grid_map_filters/BufferNormalizerFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/BufferNormalizerFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <string>
 

--- a/grid_map_filters/include/grid_map_filters/ColorBlendingFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/ColorBlendingFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <Eigen/Core>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/ColorFillFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/ColorFillFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <Eigen/Core>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/ColorMapFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/ColorMapFilter.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <grid_map_core/TypeDefs.hpp>
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <Eigen/Core>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/CurvatureFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/CurvatureFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <Eigen/Core>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/DeletionFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/DeletionFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <vector>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/DuplicationFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/DuplicationFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <string>
 

--- a/grid_map_filters/include/grid_map_filters/LightIntensityFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/LightIntensityFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <Eigen/Core>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/MathExpressionFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/MathExpressionFilter.hpp
@@ -10,7 +10,7 @@
 
 #include "EigenLab/EigenLab.h"
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <string>
 

--- a/grid_map_filters/include/grid_map_filters/MeanInRadiusFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/MeanInRadiusFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <vector>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/MedianFillFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/MedianFillFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <Eigen/Core>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/MinInRadiusFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/MinInRadiusFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <string>
 

--- a/grid_map_filters/include/grid_map_filters/MockFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/MockFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <string>
 

--- a/grid_map_filters/include/grid_map_filters/NormalColorMapFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/NormalColorMapFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <Eigen/Core>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/NormalVectorsFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/NormalVectorsFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 #include <grid_map_core/grid_map_core.hpp>
 
 #include <Eigen/Core>

--- a/grid_map_filters/include/grid_map_filters/SetBasicLayersFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/SetBasicLayersFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <vector>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/SlidingWindowMathExpressionFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/SlidingWindowMathExpressionFilter.hpp
@@ -12,7 +12,7 @@
 
 #include <grid_map_core/grid_map_core.hpp>
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <Eigen/Core>
 #include <string>

--- a/grid_map_filters/include/grid_map_filters/ThresholdFilter.hpp
+++ b/grid_map_filters/include/grid_map_filters/ThresholdFilter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filters/filter_base.hpp>
+#include <filters/filter_base.h>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
**Problem Description**
For some reason, there seems to be a change in the header path extension. I am not sure if this is a change triggered from one of the dependencies, or if this package is working with a customized dependency somewhere. 

The build fails in the following systems
- Ubuntu 16.04 Xenial ROS Kinetic
- Ubuntu 18.04 Bionic ROS Melodic
- Ubuntu 20.04 Focal ROS Noetic
```
Errors     << grid_map_cv:make /home/jaeyoung/catkin_ws/logs/grid_map_cv/build.make.004.log                                                                                                                       
In file included from /home/jaeyoung/catkin_ws/src/grid_map/grid_map_cv/src/InpaintFilter.cpp:9:0:
/home/jaeyoung/catkin_ws/src/grid_map/grid_map_cv/include/grid_map_cv/InpaintFilter.hpp:11:10: fatal error: filters/filter_base.hpp: No such file or directory
 #include <filters/filter_base.hpp>
          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/grid_map_cv.dir/src/InpaintFilter.cpp.o] Error 1
make[1]: *** [CMakeFiles/grid_map_cv.dir/all] Error 2
make: *** [all] Error 2
cd /home/jaeyoung/catkin_ws/build/grid_map_cv; catkin build --get-env grid_map_cv | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
..................................................................................................................................................................................................................
Failed     << grid_map_cv:make                      [ Exited with code 2 ]                                                                                                                                        
Failed    <<< grid_map_cv                           [ 0.3 seconds ]                                                                                                                                               
Abandoned <<< grid_map_ros                          [ Unrelated job failed ]                                                                                                                                      
Abandoned <<< grid_map_filters                      [ Unrelated job failed ]                                                                                                                                      
Abandoned <<< grid_map_loader                       [ Unrelated job failed ]                                                                                                                                      
Abandoned <<< grid_map_rviz_plugin                  [ Unrelated job failed ]                                                                                                                                      
Abandoned <<< grid_map_visualization                [ Unrelated job failed ]                                                                                                                                      
Abandoned <<< grid_map_demos                        [ Unrelated job failed ]                                                                                                                                      
[build] Summary: 3 of 10 packages succeeded.                                                                                                                                                                      
[build]   Ignored:   59 packages were skipped or are blacklisted.                                                                                                                                                 
[build]   Warnings:  None.                                                                                                                                                                                        
[build]   Abandoned: 6 packages were abandoned.                                                                                                                                                                   
[build]   Failed:    1 packages failed.                                                                                                                                                                           
[build] Runtime: 0.9 seconds total.                             
```

**Solution**
Siwtch header path extension from `filters.hpp` to `filters.h`

**Additional Context**
- This has also been reported in https://github.com/ANYbotics/grid_map/issues/292, https://github.com/ANYbotics/grid_map/issues/295