### PR TITLE
[ros2] fix convertToPointCloud function to use PCL instead of pcl_ros

### DIFF
--- a/grid_map_sdf/CMakeLists.txt
+++ b/grid_map_sdf/CMakeLists.txt
@@ -6,7 +6,7 @@ project(grid_map_sdf)
 find_package(ament_cmake REQUIRED)
 find_package(grid_map_cmake_helpers REQUIRED)
 find_package(grid_map_core REQUIRED)
-#find_package(pcl_ros REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common)
 
 ## System dependencies are found with CMake's conventions
 #find_package(Eigen3 REQUIRED)
@@ -28,7 +28,7 @@ include_directories(
 
 set(dependencies
   grid_map_core
-  #pcl_ros
+  PCL
 )
 
 ###########

--- a/grid_map_sdf/include/grid_map_sdf/SignedDistanceField.hpp
+++ b/grid_map_sdf/include/grid_map_sdf/SignedDistanceField.hpp
@@ -13,8 +13,8 @@
 
 #include <grid_map_core/GridMap.hpp>
 
-// #include <pcl/point_types.h>
-// #include <pcl/conversions.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 
 #include <string>
 #include <vector>
@@ -34,7 +34,7 @@ public:
   double getDistanceAt(const Position3 & position) const;
   Vector3 getDistanceGradientAt(const Position3 & position) const;
   double getInterpolatedDistanceAt(const Position3 & position) const;
-  // void convertToPointCloud(pcl::PointCloud<pcl::PointXYZI> & points) const;
+  void convertToPointCloud(pcl::PointCloud<pcl::PointXYZI> & points) const;
 
 private:
   Matrix getPlanarSignedDistanceField(

--- a/grid_map_sdf/package.xml
+++ b/grid_map_sdf/package.xml
@@ -16,12 +16,12 @@
   <build_depend>grid_map_cmake_helpers</build_depend>
 
   <depend>grid_map_core</depend>
-  <!-- <depend>pcl_ros</depend> -->
+  <depend>libpcl-all-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/grid_map_sdf/src/SignedDistanceField.cpp
+++ b/grid_map_sdf/src/SignedDistanceField.cpp
@@ -174,26 +174,25 @@ Vector3 SignedDistanceField::getDistanceGradientAt(const Position3 & position) c
   return Vector3(dx, dy, dz);
 }
 
-// TODO(stevemacenski): port once pcl_ros is complete
-// void SignedDistanceField::convertToPointCloud(pcl::PointCloud<pcl::PointXYZI> & points) const
-// {
-//   double xCenter = size_.x() / 2.0;
-//   double yCenter = size_.y() / 2.0;
-//   for (int z = 0; z < data_.size(); z++) {
-//     for (int y = 0; y < size_.y(); y++) {
-//       for (int x = 0; x < size_.x(); x++) {
-//         double xp = position_.x() + ((size_.x() - x) - xCenter) * resolution_;
-//         double yp = position_.y() + ((size_.y() - y) - yCenter) * resolution_;
-//         double zp = zIndexStartHeight_ + z * resolution_;
-//         pcl::PointXYZI p;
-//         p.x = xp;
-//         p.y = yp;
-//         p.z = zp;
-//         p.intensity = data_[z](x, y);
-//         points.push_back(p);
-//       }
-//     }
-//   }
-// }
+void SignedDistanceField::convertToPointCloud(pcl::PointCloud<pcl::PointXYZI> & points) const
+{
+  double xCenter = size_.x() / 2.0;
+  double yCenter = size_.y() / 2.0;
+  for (int z = 0; z < static_cast<int>(data_.size()); z++) {
+    for (int y = 0; y < static_cast<int>(size_.y()); y++) {
+      for (int x = 0; x < static_cast<int>(size_.x()); x++) {
+        double xp = position_.x() + ((size_.x() - x) - xCenter) * resolution_;
+        double yp = position_.y() + ((size_.y() - y) - yCenter) * resolution_;
+        double zp = zIndexStartHeight_ + z * resolution_;
+        pcl::PointXYZI p;
+        p.x = xp;
+        p.y = yp;
+        p.z = zp;
+        p.intensity = data_[z](x, y);
+        points.push_back(p);
+      }
+    }
+  }
+}
 
 }  // namespace grid_map


### PR DESCRIPTION
In https://github.com/ANYbotics/grid_map/issues/283 and https://github.com/ANYbotics/grid_map/issues/243, grid_map_sdf package was blocked due to pcl_ros binary not being released.
However, since grid_map_sdf only uses pure PCL library API, the dependency can be replaced with libpcl-all-dev

This PR fixes convertToPointCloud function to depend on PCL instead of pcl_ros.

This way, grid_map_ros does not have to wait for pcl_ros to be released as binary package every time new ROS distribution is released.