### PR TITLE
Restore ci setting for galactic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_and_test:
     docker:
-      - image: ros:rolling
+      - image: ros:galactic
     environment:
       ROS_WS: "/opt/ros"
       UNDERLAY_WS: "/opt/underlay_ws"
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Set Up Container
           command: |
-            apt update -qq && apt install -y build-essential cmake python3-colcon-common-extensions python3-rosdep libeigen3-dev liboctomap-dev
+            apt update -qq && apt install -y build-essential cmake python3-colcon-common-extensions python3-rosdep libeigen3-dev
             apt upgrade -y
             source `find $ROS_WS -maxdepth 2 -name local_setup.bash | sort | head -1`
             rosdep update
@@ -21,12 +21,11 @@ jobs:
             mkdir -p $UNDERLAY_WS/src && cp $OVERLAY_WS/src/grid_map/tools/ros2_dependencies.repos \
               $UNDERLAY_WS/ros2_dependencies.repos
             cd $UNDERLAY_WS && vcs import src < ros2_dependencies.repos
-            DEBIAN_FRONTEND=noninteractive  rosdep install -y --ignore-src \
-              --skip-keys "pybind11_vendor" --skip-keys "ompl" --skip-keys "slam_toolbox" --from-paths src
-            MAKEFLAGS="-j4 -l1" colcon build --symlink-install --cmake-args --parallel-workers 1 \
-              --executor sequential --packages-up-to pcl_ros octomap_msgs nav2_costmap_2d
+            DEBIAN_FRONTEND=noninteractive  rosdep install -y --ignore-src --from-paths src
+            colcon build --symlink-install --cmake-args --parallel-workers 1 --packages-up-to \
+              pcl_ros
             source $UNDERLAY_WS/install/setup.bash
-            cd $OVERLAY_WS && rosdep install -y --ignore-src --from-paths src --skip-keys "octomap"
+            cd $OVERLAY_WS && rosdep install -y --ignore-src --from-paths src
       - run:
           name: Debug Build
           command: |


### PR DESCRIPTION
This PR should be merged after
- docker image for `galactic` is ready. https://github.com/osrf/docker_images/pull/532
- `nav2_costmap_2d` is released for `galactic`