### PR TITLE
Minor fix in getClosestPosition to avoid wrong indices

### DIFF
--- a/grid_map_core/src/GridMap.cpp
+++ b/grid_map_core/src/GridMap.cpp
@@ -719,18 +719,18 @@ Position GridMap::getClosestPositionInMap(const Position& position) const {
   const Position3 bottomRightCorner(position_.x() - halfLengthX, position_.y() - halfLengthY, 0.0);
 
   // Find constraints.
-  const double maxX = topRightCorner.x();
+  const double maxX = topLeftCorner.x();
   const double minX = bottomRightCorner.x();
-  const double maxY = bottomLeftCorner.y();
+  const double maxY = topLeftCorner.y();
   const double minY = bottomRightCorner.y();
 
   // Clip to box constraints and correct for indexing precision.
   // Points on the border can lead to invalid indices because the cells represent half open intervals, i.e. [...).
-  positionInMap.x() = std::fmin(positionInMap.x(), maxX - std::numeric_limits<double>::epsilon());
-  positionInMap.y() = std::fmin(positionInMap.y(), maxY - std::numeric_limits<double>::epsilon());
+  positionInMap.x() = std::fmin(positionInMap.x(), maxX - 10.0 * std::numeric_limits<double>::epsilon());
+  positionInMap.y() = std::fmin(positionInMap.y(), maxY - 10.0 * std::numeric_limits<double>::epsilon());
 
-  positionInMap.x() = std::fmax(positionInMap.x(), minX + std::numeric_limits<double>::epsilon());
-  positionInMap.y() = std::fmax(positionInMap.y(), minY + std::numeric_limits<double>::epsilon());
+  positionInMap.x() = std::fmax(positionInMap.x(), minX + 10.0 * std::numeric_limits<double>::epsilon());
+  positionInMap.y() = std::fmax(positionInMap.y(), minY + 10.0 * std::numeric_limits<double>::epsilon());
 
   return positionInMap;
 }


### PR DESCRIPTION
Hi, this is a minor fix when using `getClosestPosition()` with positions outside the grid map.

The actual implementation used the `std::epsilon` value to avoid this but I still observed some issues when calling `getIndex()`. I used the same factor of 10 for epsilon used [here](https://github.com/ANYbotics/grid_map/blob/master/grid_map_core/src/GridMapMath.cpp#L250) and seems to do the trick (I guess that just using epsilon is still too tight)

