### PR TITLE
Fix mismatching version in sub-modules

### DIFF
--- a/grid_map_costmap_2d/package.xml
+++ b/grid_map_costmap_2d/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>grid_map_costmap_2d</name>
-  <version>1.6.2</version>
+  <version>2.0.0</version>
   <description>Interface for grid maps to the costmap_2d format.</description>
   <maintainer email="mwulf@anybotics.com">Maximilian Wulf</maintainer>
   <maintainer email="ynava@anybotics.com">Yoshua Nava</maintainer>


### PR DESCRIPTION
Mismatching versions in sub-modules (1.6.2 vs. 2.0.0), may lead to issues with git-bloom-release.