### PR TITLE
Add PointCloud2ToGridMapMsg node

### DIFF
--- a/grid_map_pcl/CMakeLists.txt
+++ b/grid_map_pcl/CMakeLists.txt
@@ -99,7 +99,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 
-# Node.
+# Node grid_map_pcl_loader_node
 add_executable(grid_map_pcl_loader_node
   src/grid_map_pcl_loader_node.cpp
 )
@@ -114,6 +114,24 @@ target_include_directories(grid_map_pcl_loader_node SYSTEM PUBLIC
   ${EIGEN3_INCLUDE_DIR}
 )
 target_link_libraries(grid_map_pcl_loader_node
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+)
+# Node PointCloud2_to_GridMap_msg_node
+add_executable(PointCloud2_to_GridMap_msg_node
+  src/PointCloud2_to_GridMap_msg_node.cpp
+)
+add_dependencies(PointCloud2_to_GridMap_msg_node
+  ${PROJECT_NAME}
+)
+target_include_directories(PointCloud2_to_GridMap_msg_node PRIVATE
+  include
+)
+target_include_directories(PointCloud2_to_GridMap_msg_node SYSTEM PUBLIC
+  ${catkin_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIR}
+)
+target_link_libraries(PointCloud2_to_GridMap_msg_node
   ${PROJECT_NAME}
   ${catkin_LIBRARIES}
 )

--- a/grid_map_pcl/README.md
+++ b/grid_map_pcl/README.md
@@ -35,10 +35,15 @@ The algorithm will open the .pcd file, convert the point cloud to a grid map and
 1.  Place .pcd files in the package folder or anywhere on the system (e.g. grid_map_pcl/data/example.pcd).
 2.  Modify the *folder_path* inside the launch file such that the folder file points to the folder containing .pcd files (e.g. /*"path to the grid_map_pcl folder"*/data).
 3.  Change the *pcd_filename* to the point cloud file that you want to process
-4.  You can run the algorithm with: *roslaunch grid_map_pcl grid_map_pcl_loader_node.launch* 
+4.  You can run the algorithm with: `roslaunch grid_map_pcl grid_map_pcl_loader_node.launch`
 5.  Once the algorithm is done you will see the output in the console, then you can run rviz in a separate terminal (make sure that you have sourced your workspace, **DO NOT CLOSE** the terminal where *grid_map_pcl_loader_node* is running ) and visualize the resulting grid map. Instructions on how to visualize a grid map are in the grid map [README](../README.md).
 
 The resulting grid map will be saved in the folder given by *folder_path* variable in the launch file and will be named with a string contained inside the *output_grid_map* variable. For large point clouds (100M-140M points) the algorithm takes about 30-60 min to finish (with 6 threads). For sizes that are in the range of 40M to 60M points, the runtime varies between 5 and 15 min, depending on the number of points. Point cloud with around 10M points or less can be processed in a minute or two.
+
+Alternatively, you can also convert ROS `sensor_msgs::PointCloud2` to `grid_map_msgs::GridMap` messages by running:
+```bash
+roslaunch grid_map_pcl PointCloud2_to_GridMap_msg_node.launch
+```
 
 ## Parameters
 

--- a/grid_map_pcl/include/grid_map_pcl/GridMapPclLoader.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/GridMapPclLoader.hpp
@@ -49,6 +49,12 @@ class GridMapPclLoader {
   void loadCloudFromPcdFile(const std::string& filename);
 
   /*!
+   * Loads the point cloud from a PointCloud2 message into memory
+   * @param[in] fullpath to the point cloud.
+   */
+  void loadCloudFromMessage(const sensor_msgs::PointCloud2& msg);
+
+  /*!
    * Allows the user to set the input cloud
    * @param[in] pointer to the input point cloud.
    */

--- a/grid_map_pcl/include/grid_map_pcl/PointCloud2_to_GridMap_msg_node.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/PointCloud2_to_GridMap_msg_node.hpp
@@ -12,14 +12,28 @@
 //namespace grid_map_pcl {
 class PointCloud2ToGridMapMsgNode
 {
+    public:
+        /*!
+        * Constructor.
+        * @param nodeHandle the ROS node handle.
+        */
+        PointCloud2ToGridMapMsgNode(ros::NodeHandle& nodeHandle);
+        ~PointCloud2ToGridMapMsgNode();
+
+        /*!
+        * Callback function for the point cloud 2.
+        * @param message the point cloud2 message to be converted to a grid map msg
+        */
+        void callback(const sensor_msgs::PointCloud2 & msg);
+
     private:
         std::string gridMapTopic_;
         std::string pointCloudTopic_;
 
+        //! ROS nodehandle.
+        ros::NodeHandle nodeHandle_;
+
         ros::Subscriber sub_;
         ros::Publisher pub_;
-    public:
-        PointCloud2ToGridMapMsgNode(ros::NodeHandle& nodeHandle);
-        ~PointCloud2ToGridMapMsgNode();
 };
 //}

--- a/grid_map_pcl/include/grid_map_pcl/PointCloud2_to_GridMap_msg_node.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/PointCloud2_to_GridMap_msg_node.hpp
@@ -24,7 +24,7 @@ class PointCloud2ToGridMapMsgNode
         * Callback function for the point cloud 2.
         * @param message the point cloud2 message to be converted to a grid map msg
         */
-        void callback(const sensor_msgs::PointCloud2 & msg);
+        void sub_callback(const sensor_msgs::PointCloud2 & msg);
 
     private:
         std::string gridMapTopic_;

--- a/grid_map_pcl/include/grid_map_pcl/PointCloud2_to_GridMap_msg_node.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/PointCloud2_to_GridMap_msg_node.hpp
@@ -1,0 +1,25 @@
+/*
+ * PointCloud2_to_GridMap_msg_node.hpp
+ *
+ *  Created on: July 03, 2021
+ *      Author: Maximilian Stölzle
+ *      Institute: ETH Zurich, Robotic Systems Lab
+ */
+
+#include <ros/ros.h>
+
+
+//namespace grid_map_pcl {
+class PointCloud2ToGridMapMsgNode
+{
+    private:
+        std::string gridMapTopic_;
+        std::string pointCloudTopic_;
+
+        ros::Subscriber sub_;
+        ros::Publisher pub_;
+    public:
+        PointCloud2ToGridMapMsgNode(ros::NodeHandle& nodeHandle);
+        ~PointCloud2ToGridMapMsgNode();
+};
+//}

--- a/grid_map_pcl/include/grid_map_pcl/PointCloud2_to_GridMap_msg_node.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/PointCloud2_to_GridMap_msg_node.hpp
@@ -7,6 +7,7 @@
  */
 
 #include <ros/ros.h>
+#include "grid_map_pcl/GridMapPclLoader.hpp"
 
 
 //namespace grid_map_pcl {

--- a/grid_map_pcl/launch/PointCloud2_to_GridMap_msg_node.launch
+++ b/grid_map_pcl/launch/PointCloud2_to_GridMap_msg_node.launch
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <launch>
-  <arg name="point_cloud_topic"      default="point_cloud" />
-  <arg name="grid_map_topic"         default="grid_map" />
+  <arg name="point_cloud_topic"      default="/omni_stitched_cloud"/>
+  <arg name="grid_map_topic"         default="/grid_map" />
   <arg name="map_frame"              default="map" />
   <arg name="map_layer_name"         default="elevation" />
   <arg name="prefix"                 default=""/>

--- a/grid_map_pcl/launch/PointCloud2_to_GridMap_msg_node.launch
+++ b/grid_map_pcl/launch/PointCloud2_to_GridMap_msg_node.launch
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<launch>
+  <arg name="point_cloud_topic"      default="point_cloud" />
+  <arg name="grid_map_topic"         default="grid_map" />
+  <arg name="map_frame"              default="map" />
+  <arg name="map_layer_name"         default="elevation" />
+  <arg name="prefix"                 default=""/>
+  <arg name="set_verbosity_to_debug" default="false"/>
+    
+  <node name="PointCloud2_to_GridMap_msg_node" pkg="grid_map_pcl"
+      type="PointCloud2_to_GridMap_msg_node" output="screen" launch-prefix="$(arg prefix)">
+    <rosparam file="$(find grid_map_pcl)/config/parameters.yaml" />
+    <param name="point_cloud_topic"       type="string" value="$(arg point_cloud_topic)" />
+    <param name="grid_map_topic"          type="string" value="$(arg grid_map_topic)" />
+    <param name="map_frame"               type="string" value="$(arg map_frame)" />
+    <param name="map_layer_name"          type="string" value="$(arg map_layer_name)" />
+    <param name="set_verbosity_to_debug"  type="bool" value="$(arg set_verbosity_to_debug)" />
+  </node>
+</launch>

--- a/grid_map_pcl/src/GridMapPclLoader.cpp
+++ b/grid_map_pcl/src/GridMapPclLoader.cpp
@@ -14,6 +14,7 @@
 
 #include <pcl/common/io.h>
 #include <ros/console.h>
+#include <pcl_ros/point_cloud.h>
 
 #include <grid_map_core/GridMapMath.hpp>
 
@@ -29,6 +30,12 @@ const grid_map::GridMap& GridMapPclLoader::getGridMap() const {
 void GridMapPclLoader::loadCloudFromPcdFile(const std::string& filename) {
   Pointcloud::Ptr inputCloud(new pcl::PointCloud<pcl::PointXYZ>);
   inputCloud = grid_map_pcl::loadPointcloudFromPcd(filename);
+  setInputCloud(inputCloud);
+}
+
+void GridMapPclLoader::loadCloudFromMessage(const sensor_msgs::PointCloud2& msg) {
+  Pointcloud::Ptr inputCloud (new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::fromROSMsg(msg, *inputCloud);
   setInputCloud(inputCloud);
 }
 

--- a/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
+++ b/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
@@ -45,6 +45,7 @@ void PointCloud2ToGridMapMsgNode::sub_callback(const sensor_msgs::PointCloud2 & 
 
   // load PCL point cloud from message
   gridMapPclLoader.loadCloudFromMessage(point_cloud_msg);
+  gm::processPointcloud(&gridMapPclLoader, nodeHandle_);
 
   // create grid map
   grid_map::GridMap gridMap = gridMapPclLoader.getGridMap();

--- a/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
+++ b/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
@@ -20,16 +20,19 @@ namespace gm = ::grid_map::grid_map_pcl;
 PointCloud2ToGridMapMsgNode::PointCloud2ToGridMapMsgNode(ros::NodeHandle& nodeHandle)
 {
   ROS_INFO("PointCloud2ToGridMapMsgNode started.");
+  nodeHandle_ = nodeHandle;
+
   // activityCheckTimer_ = nodeHandle_.createTimer(activityCheckDuration_,
   //                                               &GridMapVisualization::updateSubscriptionCallback,
   //                                               this);
+
   // Publisher
-  // nh.param<std::string>("grid_map_topic", gridMapTopic_, "grid_map");
-  // pub_ = nh.advertise<grid_map_msgs::GridMap>(gridMapTopic_, 1, true);
+  nodeHandle_.param<std::string>("grid_map_topic", gridMapTopic_, "grid_map");
+  pub_ = nodeHandle_.advertise<grid_map_msgs::GridMap>(gridMapTopic_, 1, true);
 
   // // Subscriber
-  // nh.param<std::string>("point_cloud_topic", pointCloudTopic_, "point_cloud");
-  // sub_ = nh.subscribe(pointCloudTopic_, 1, callback);
+  // nodeHandle_.param<std::string>("point_cloud_topic", pointCloudTopic_, "point_cloud");
+  // sub_ = nodeHandle_.subscribe(pointCloudTopic_, 1, callback);
 
 }
 
@@ -38,30 +41,30 @@ PointCloud2ToGridMapMsgNode::~PointCloud2ToGridMapMsgNode()
   ROS_INFO("PointCloud2ToGridMapMsgNode deconstructed.");
 }
 
-void callback(const sensor_msgs::PointCloud2::ConstPtr& msg) {
-  // gridMapPclLoader.loadCloudFromMessage(pathToCloud);
+// void callback(const sensor_msgs::PointCloud2::ConstPtr& msg) {
+//   // gridMapPclLoader.loadCloudFromMessage(pathToCloud);
 
-  // grid_map::GridMapPclLoader gridMapPclLoader;
-  // gridMapPclLoader.loadParameters(gm::getParameterPath());
-  // gridMapPclLoader.loadCloudFromMessage(pathToCloud);
+//   // grid_map::GridMapPclLoader gridMapPclLoader;
+//   // gridMapPclLoader.loadParameters(gm::getParameterPath());
+//   // gridMapPclLoader.loadCloudFromMessage(pathToCloud);
 
-  // gm::processPointcloud(&gridMapPclLoader, nh);
+//   // gm::processPointcloud(&gridMapPclLoader, nh);
 
-  // grid_map::GridMap gridMap = gridMapPclLoader.getGridMap();
-  // gridMap.setFrameId(gm::getMapFrame(nh));
+//   // grid_map::GridMap gridMap = gridMapPclLoader.getGridMap();
+//   // gridMap.setFrameId(gm::getMapFrame(nh));
 
-  // // publish grid map
-  // grid_map_msgs::GridMap msg;
-  // grid_map::GridMapRosConverter::toMessage(gridMap, msg);
-  // pub.publish(msg);
-}
+//   // // publish grid map
+//   // grid_map_msgs::GridMap msg;
+//   // grid_map::GridMapRosConverter::toMessage(gridMap, msg);
+//   // pub.publish(msg);
+// }
 
 int main(int argc, char** argv) {
   ROS_INFO("Launched PointCloud2_to_GridMap_msg_node");
 
   ros::init(argc, argv, "PointCloud2_to_GridMap_msg_node");
-  ros::NodeHandle nh("~");
-  gm::setVerbosityLevelToDebugIfFlagSet(nh);
+  ros::NodeHandle nodeHandle("~");
+  gm::setVerbosityLevelToDebugIfFlagSet(nodeHandle);
 
   // // Publisher
   // std::string gridMapTopic;
@@ -73,8 +76,6 @@ int main(int argc, char** argv) {
   // std::string pointCloudTopic;
   // nh.param<std::string>("point_cloud_topic", pointCloudTopic, "point_cloud");
   // ros::Subscriber sub = nh.subscribe(pointCloudTopic, 1, callback);
-
-  ros::NodeHandle nodeHandle("~");
 
   PointCloud2ToGridMapMsgNode node = PointCloud2ToGridMapMsgNode(nodeHandle);
 

--- a/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
+++ b/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
@@ -19,7 +19,7 @@ namespace gm = ::grid_map::grid_map_pcl;
 
 PointCloud2ToGridMapMsgNode::PointCloud2ToGridMapMsgNode(ros::NodeHandle& nodeHandle)
 {
-  ROS_INFO("PointCloud2ToGridMapMsgNode started.");
+  ROS_INFO("PointCloud2ToGridMapMsgNode started");
   nodeHandle_ = nodeHandle;
 
   // Publisher
@@ -34,11 +34,12 @@ PointCloud2ToGridMapMsgNode::PointCloud2ToGridMapMsgNode(ros::NodeHandle& nodeHa
 
 PointCloud2ToGridMapMsgNode::~PointCloud2ToGridMapMsgNode()
 {
-  ROS_INFO("PointCloud2ToGridMapMsgNode deconstructed.");
+  ROS_INFO("PointCloud2ToGridMapMsgNode deconstructed");
 }
 
 void PointCloud2ToGridMapMsgNode::sub_callback(const sensor_msgs::PointCloud2 & point_cloud_msg) 
 {
+  ROS_INFO("Received PointCloud2 message");
   // init GridMapPclLoader
   grid_map::GridMapPclLoader gridMapPclLoader;
 

--- a/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
+++ b/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
@@ -31,14 +31,19 @@ PointCloud2ToGridMapMsgNode::PointCloud2ToGridMapMsgNode(ros::NodeHandle& nodeHa
   pub_ = nodeHandle_.advertise<grid_map_msgs::GridMap>(gridMapTopic_, 1, true);
 
   // // Subscriber
-  // nodeHandle_.param<std::string>("point_cloud_topic", pointCloudTopic_, "point_cloud");
-  // sub_ = nodeHandle_.subscribe(pointCloudTopic_, 1, callback);
+  nodeHandle_.param<std::string>("point_cloud_topic", pointCloudTopic_, "point_cloud");
+  sub_ = nodeHandle_.subscribe(pointCloudTopic_, 1, &PointCloud2ToGridMapMsgNode::sub_callback, this);
 
 }
 
 PointCloud2ToGridMapMsgNode::~PointCloud2ToGridMapMsgNode()
 {
   ROS_INFO("PointCloud2ToGridMapMsgNode deconstructed.");
+}
+
+void PointCloud2ToGridMapMsgNode::sub_callback(const sensor_msgs::PointCloud2 & msg) 
+{
+
 }
 
 // void callback(const sensor_msgs::PointCloud2::ConstPtr& msg) {

--- a/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
+++ b/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
@@ -1,0 +1,84 @@
+/*
+ * PointCloud2_to_GridMap_msg_node.cpp
+ *
+ *  Created on: June 25, 2021
+ *      Author: Maximilian Stölzle
+ *      Institute: ETH Zurich, Robotic Systems Lab
+ */
+
+#include <ros/ros.h>
+
+#include <grid_map_core/GridMap.hpp>
+#include <grid_map_ros/GridMapRosConverter.hpp>
+
+#include "grid_map_pcl/PointCloud2_to_GridMap_msg_node.hpp"
+#include "grid_map_pcl/GridMapPclLoader.hpp"
+#include "grid_map_pcl/helpers.hpp"
+
+namespace gm = ::grid_map::grid_map_pcl;
+
+PointCloud2ToGridMapMsgNode::PointCloud2ToGridMapMsgNode(ros::NodeHandle& nodeHandle)
+{
+  ROS_INFO("PointCloud2ToGridMapMsgNode started.");
+  // activityCheckTimer_ = nodeHandle_.createTimer(activityCheckDuration_,
+  //                                               &GridMapVisualization::updateSubscriptionCallback,
+  //                                               this);
+  // Publisher
+  // nh.param<std::string>("grid_map_topic", gridMapTopic_, "grid_map");
+  // pub_ = nh.advertise<grid_map_msgs::GridMap>(gridMapTopic_, 1, true);
+
+  // // Subscriber
+  // nh.param<std::string>("point_cloud_topic", pointCloudTopic_, "point_cloud");
+  // sub_ = nh.subscribe(pointCloudTopic_, 1, callback);
+
+}
+
+PointCloud2ToGridMapMsgNode::~PointCloud2ToGridMapMsgNode()
+{
+  ROS_INFO("PointCloud2ToGridMapMsgNode deconstructed.");
+}
+
+void callback(const sensor_msgs::PointCloud2::ConstPtr& msg) {
+  // gridMapPclLoader.loadCloudFromMessage(pathToCloud);
+
+  // grid_map::GridMapPclLoader gridMapPclLoader;
+  // gridMapPclLoader.loadParameters(gm::getParameterPath());
+  // gridMapPclLoader.loadCloudFromMessage(pathToCloud);
+
+  // gm::processPointcloud(&gridMapPclLoader, nh);
+
+  // grid_map::GridMap gridMap = gridMapPclLoader.getGridMap();
+  // gridMap.setFrameId(gm::getMapFrame(nh));
+
+  // // publish grid map
+  // grid_map_msgs::GridMap msg;
+  // grid_map::GridMapRosConverter::toMessage(gridMap, msg);
+  // pub.publish(msg);
+}
+
+int main(int argc, char** argv) {
+  ROS_INFO("Launched PointCloud2_to_GridMap_msg_node");
+
+  ros::init(argc, argv, "PointCloud2_to_GridMap_msg_node");
+  ros::NodeHandle nh("~");
+  gm::setVerbosityLevelToDebugIfFlagSet(nh);
+
+  // // Publisher
+  // std::string gridMapTopic;
+  // nh.param<std::string>("grid_map_topic", gridMapTopic, "grid_map");
+  // ros::Publisher pub;
+  // pub = nh.advertise<grid_map_msgs::GridMap>(gridMapTopic, 1, true);
+
+  // // Subscriber
+  // std::string pointCloudTopic;
+  // nh.param<std::string>("point_cloud_topic", pointCloudTopic, "point_cloud");
+  // ros::Subscriber sub = nh.subscribe(pointCloudTopic, 1, callback);
+
+  ros::NodeHandle nodeHandle("~");
+
+  PointCloud2ToGridMapMsgNode node = PointCloud2ToGridMapMsgNode(nodeHandle);
+
+  // run
+  ros::spin();
+  return EXIT_SUCCESS;
+}

--- a/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
+++ b/grid_map_pcl/src/PointCloud2_to_GridMap_msg_node.cpp
@@ -42,6 +42,7 @@ void PointCloud2ToGridMapMsgNode::sub_callback(const sensor_msgs::PointCloud2 & 
   ROS_INFO("Received PointCloud2 message");
   // init GridMapPclLoader
   grid_map::GridMapPclLoader gridMapPclLoader;
+  gridMapPclLoader.loadParameters(gm::getParameterPath());
 
   // load PCL point cloud from message
   gridMapPclLoader.loadCloudFromMessage(point_cloud_msg);


### PR DESCRIPTION
The purpose of this node is to make it easier to directly generate `GridMap` messages from `PointCloud2` messages. This enables to directly convert point clouds to grid maps either online on the robot or offline from and to rosbags.