### PR TITLE
fix inline function for helpers in grid_map_pcl

### DIFF
--- a/grid_map_pcl/include/grid_map_pcl/helpers.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/helpers.hpp
@@ -44,7 +44,13 @@ void saveGridMap(
 inline void printTimeElapsedToRosInfoStream(
   const std::chrono::system_clock::time_point & start,
   const std::string & prefix,
-  const rclcpp::Logger & node_logger);
+  const rclcpp::Logger & node_logger)
+{
+  const auto stop = std::chrono::high_resolution_clock::now();
+  const auto duration =
+    std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count() / 1000.0;
+  RCLCPP_INFO_STREAM(node_logger, prefix << duration << " sec");
+}
 
 void processPointcloud(
   grid_map::GridMapPclLoader * gridMapPclLoader,

--- a/grid_map_pcl/src/helpers.cpp
+++ b/grid_map_pcl/src/helpers.cpp
@@ -126,17 +126,6 @@ void saveGridMap(
     node->get_logger(), "Saving grid map successful: " << std::boolalpha << savingSuccessful);
 }
 
-inline void printTimeElapsedToRosInfoStream(
-  const std::chrono::system_clock::time_point & start,
-  const std::string & prefix,
-  const rclcpp::Logger & node_logger)
-{
-  const auto stop = std::chrono::high_resolution_clock::now();
-  const auto duration =
-    std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count() / 1000.0;
-  RCLCPP_INFO_STREAM(node_logger, prefix << duration << " sec");
-}
-
 void processPointcloud(
   grid_map::GridMapPclLoader * gridMapPclLoader,
   rclcpp::Node::SharedPtr & node)


### PR DESCRIPTION
### Description

- fix build problem when inline function is not defined in `*.hpp`.

### Details

I have the following build error when using `helpers.hpp` in `grid_map_pcl` at my project.

```
In file included from /home/hrkota/dev/autoware.proj/install/grid_map_pcl/include/grid_map_pcl/PointcloudProcessor.hpp:16,
                 from /home/hrkota/dev/autoware.proj/install/grid_map_pcl/include/grid_map_pcl/GridMapPclLoader.hpp:21,
                 from /home/hrkota/dev/autoware.proj/src/autoware/autoware.iv/map/map_loader/src/elevation_map_loader/elevation_map_loader_node.cpp:26:
/home/hrkota/dev/autoware.proj/install/grid_map_pcl/include/grid_map_pcl/helpers.hpp:44:13: error: inline function ‘void grid_map::grid_map_pcl::printTimeElapsedToRosInfoStream(const time_point&, const string&, const rclcpp::Logger&)’ used but never defined [-Werror]
   44 | inline void printTimeElapsedToRosInfoStream(
      |            
```



