### PR TITLE
Add action-ros-ci

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,43 @@
+name: Build and test
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distribution:
+          - galactic
+          - rolling
+        include:
+          # Galactic Geochelone (May 2021 - November 2022)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-galactic-ros-base-latest
+            ros_distribution: galactic
+            ros_version: 2
+          # Rolling Ridley  (June 2020 - Present)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-rolling-ros-base-latest
+            ros_distribution: rolling
+            ros_version: 2
+    container:
+      image: ${{ matrix.docker_image }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Search packages in this repository
+        id: list_packages
+        run: |
+          echo ::set-output name=package_list::$(colcon list --names-only)
+
+      - name: Run action-ros-ci
+        uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          package-name: ${{ steps.list_packages.outputs.package_list }}
+          target-ros2-distro: ${{ matrix.ros_distribution }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,3 +41,4 @@ jobs:
         with:
           package-name: ${{ steps.list_packages.outputs.package_list }}
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: build_depends.${{ matrix.ros_distribution }}.repos

--- a/build_depends.galactic.repos
+++ b/build_depends.galactic.repos
@@ -1,0 +1,1 @@
+repositories:

--- a/build_depends.rolling.repos
+++ b/build_depends.rolling.repos
@@ -1,0 +1,5 @@
+repositories:
+  ros-planning/navigation2:
+    type: git
+    url: https://github.com/ros-planning/navigation2.git
+    version: main


### PR DESCRIPTION
When I sent a PR(https://github.com/ANYbotics/grid_map/pull/318), I found I can't check the reason of CI failure.
![image](https://user-images.githubusercontent.com/31987104/130792116-cc0acb24-1f46-42b5-a0b1-eaaf7e40b9dc.png)

So I added a workflow of GitHub Actions that will build and test packages using `action-ros-ci`.

I've tested it here. https://github.com/kenji-miyake/grid_map/actions/runs/1166315854
Although `rolling` failed probably due to API changes, `galactic` passed the test.