### PR TITLE
Fix deprecated to_yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ jobs:
               $UNDERLAY_WS/ros2_dependencies.repos
             cd $UNDERLAY_WS && vcs import src < ros2_dependencies.repos
             DEBIAN_FRONTEND=noninteractive  rosdep install -y --ignore-src \
-              --skip-keys "pybind11_vendor" --skip-keys "ompl" --skip-keys "slam_toolbox" --from-paths src
+              --skip-keys "slam_toolbox" --from-paths src
             MAKEFLAGS="-j4 -l1" colcon build --symlink-install --cmake-args --parallel-workers 1 \
-              --executor sequential --packages-up-to pcl_ros octomap_msgs nav2_costmap_2d
+              --executor sequential --packages-up-to nav2_costmap_2d
             source $UNDERLAY_WS/install/setup.bash
-            cd $OVERLAY_WS && rosdep install -y --ignore-src --from-paths src --skip-keys "octomap"
+            cd $OVERLAY_WS && rosdep install -y --ignore-src --from-paths src
       - run:
           name: Debug Build
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,40 +4,27 @@ jobs:
   build_and_test:
     docker:
       - image: ros:rolling
-    environment:
-      ROS_WS: "/opt/ros"
-      UNDERLAY_WS: "/opt/underlay_ws"
-      OVERLAY_WS: "/opt/overlay_ws"
     steps:
       - checkout
       - run:
-          name: Set Up Container
+          name: Setup workspace
           command: |
-            apt update -qq && apt install -y build-essential cmake python3-colcon-common-extensions python3-rosdep libeigen3-dev liboctomap-dev
-            apt upgrade -y
-            source `find $ROS_WS -maxdepth 2 -name local_setup.bash | sort | head -1`
+            mkdir -p src/grid_map
+            mv `find -maxdepth 1 -not -name . -not -name src` src/grid_map/
+            vcs import src < src/grid_map/tools/ros2_dependencies.repos
+            apt-get update
+            apt-get upgrade
             rosdep update
-            mkdir -p $OVERLAY_WS/src/grid_map && mv `find -maxdepth 1 -not -name . -not -name src` $OVERLAY_WS/src/grid_map/
-            mkdir -p $UNDERLAY_WS/src && cp $OVERLAY_WS/src/grid_map/tools/ros2_dependencies.repos \
-              $UNDERLAY_WS/ros2_dependencies.repos
-            cd $UNDERLAY_WS && vcs import src < ros2_dependencies.repos
-            DEBIAN_FRONTEND=noninteractive  rosdep install -y --ignore-src \
-              --skip-keys "slam_toolbox" --from-paths src
-            MAKEFLAGS="-j4 -l1" colcon build --symlink-install --cmake-args --parallel-workers 1 \
-              --executor sequential --packages-up-to nav2_costmap_2d
-            source $UNDERLAY_WS/install/setup.bash
-            cd $OVERLAY_WS && rosdep install -y --ignore-src --from-paths src
+            DEBIAN_FRONTEND=noninteractive rosdep install -iry --from-paths . --rosdistro $ROS_DISTRO \
+              --skip-keys "slam_toolbox"
       - run:
           name: Debug Build
           command: |
-            source $UNDERLAY_WS/install/setup.bash
-            cd $OVERLAY_WS && colcon build --parallel-workers 1
+            colcon build --parallel-workers 1 --packages-up-to $(colcon list --names-only --base-paths src/grid_map/)
       - run:
           name: Run Tests
           command: |
-            source $UNDERLAY_WS/install/setup.bash
-            cd $OVERLAY_WS
-            colcon test --parallel-workers 1
+            colcon test --parallel-workers 1 --packages-select $(colcon list --names-only --base-paths src/grid_map/)
             colcon test-result --verbose
 workflows:
   version: 2

--- a/grid_map_ros/src/GridMapRosConverter.cpp
+++ b/grid_map_ros/src/GridMapRosConverter.cpp
@@ -275,7 +275,7 @@ bool GridMapRosConverter::fromOccupancyGrid(
     RCLCPP_INFO(
       rclcpp::get_logger("fromOccupancyGrid"),
       "Orientation of occupancy grid: \n%s",
-      rosidl_generator_traits::to_yaml(occupancyGrid.info.origin.orientation).c_str());
+      geometry_msgs::msg::to_yaml(occupancyGrid.info.origin.orientation).c_str());
     return false;
   }
 
@@ -374,7 +374,7 @@ bool GridMapRosConverter::fromCostmap(
     RCLCPP_INFO(
       rclcpp::get_logger("fromcostmap"),
       "Orientation of costmap: \n%s",
-      rosidl_generator_traits::to_yaml(costmap.metadata.origin.orientation).c_str());
+      geometry_msgs::msg::to_yaml(costmap.metadata.origin.orientation).c_str());
     return false;
   }
 

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -1,13 +1,5 @@
 repositories:
-  ros-perception/perception_pcl:
-    type: git
-    url: https://github.com/ros-perception/perception_pcl.git
-    version: foxy-devel
   ros-planning/navigation2:
     type: git
     url: https://github.com/ros-planning/navigation2.git
     version: main
-  OctoMap/octomap_msgs:
-    type: git
-    url: https://github.com/OctoMap/octomap_msgs.git
-    version: ros2


### PR DESCRIPTION
Fixed this error.

```sh
/home/kenji/gridmap_ws/grid_map/grid_map_ros/src/GridMapRosConverter.cpp:377:75: error: ‘std::string rosidl_generator_traits::to_yaml(const Quaternion&)’ is deprecated: use geometry_msgs::msg::to_yaml() instead [-Werror=deprecated-declarations]
  377 |       rosidl_generator_traits::to_yaml(costmap.metadata.origin.orientation).c_str());
```