### PR TITLE
Add height of cluster with the most points method

### DIFF
--- a/grid_map_pcl/README.md
+++ b/grid_map_pcl/README.md
@@ -54,7 +54,7 @@ Resulting grid map parameters.
 * **pcl_grid_map_extraction/grid_map/height_type** How to calculate elevation value.
 0: Smallest value among the average values ​​of each cluster
 1: Mean value of the cluster with the most points
-* **pcl_grid_map_extraction/grid_map/height_thresh** Height range from the smallest cluster.(For only height_type 1)
+* **pcl_grid_map_extraction/grid_map/height_thresh** Height range from the smallest cluster.(Only for height_type 1)
 
 ### Point Cloud Pre-processing Parameters
 

--- a/grid_map_pcl/README.md
+++ b/grid_map_pcl/README.md
@@ -51,6 +51,10 @@ The resulting grid map will be saved in the folder given by *folder_path* variab
 Resulting grid map parameters.
 * **pcl_grid_map_extraction/grid_map/min_num_points_per_cell** Minimum number of points in the point cloud that have to fall within any of the grid map cells. Otherwise the cell elevation will be set to NaN.
 * **pcl_grid_map_extraction/grid_map/resolution** Resolution of the grid map. Width and lengts are computed automatically.
+* **pcl_grid_map_extraction/grid_map/height_type** How to calculate elevation value.
+0: Smallest value among the average values ​​of each cluster
+1: Mean value of the cluster with the most points
+* **pcl_grid_map_extraction/grid_map/height_thresh** Height range from the smallest cluster.(For only height_type 1)
 
 ### Point Cloud Pre-processing Parameters
 

--- a/grid_map_pcl/config/parameters.yaml
+++ b/grid_map_pcl/config/parameters.yaml
@@ -26,6 +26,9 @@ pcl_grid_map_extraction:
   grid_map:
     min_num_points_per_cell: 4
     resolution: 0.1
+    # 0: Smallest value among the average values ​​of each cluster
+    # 1: Mean value of the cluster with the most points
+    height_type: 0
 
     
        

--- a/grid_map_pcl/config/parameters.yaml
+++ b/grid_map_pcl/config/parameters.yaml
@@ -29,6 +29,8 @@ pcl_grid_map_extraction:
     # 0: Smallest value among the average values ​​of each cluster
     # 1: Mean value of the cluster with the most points
     height_type: 0
+    # For height_type 1
+    height_thresh: 1.0
 
     
        

--- a/grid_map_pcl/include/grid_map_pcl/PclLoaderParameters.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/PclLoaderParameters.hpp
@@ -62,6 +62,9 @@ class PclLoaderParameters
   {
     double resolution_ = 0.1;
     unsigned int minCloudPointsPerCell_ = 2;
+    // 0: Smallest value among the average values ​​of each cluster
+    // 1: Mean value of the cluster with the most points
+    unsigned int height_type_ = 0;
   };
 
   struct Parameters

--- a/grid_map_pcl/include/grid_map_pcl/PclLoaderParameters.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/PclLoaderParameters.hpp
@@ -65,6 +65,8 @@ class PclLoaderParameters
     // 0: Smallest value among the average values ​​of each cluster
     // 1: Mean value of the cluster with the most points
     unsigned int height_type_ = 0;
+    // For height_type 1
+    double height_thresh_ = 1.0;
   };
 
   struct Parameters

--- a/grid_map_pcl/src/GridMapPclLoader.cpp
+++ b/grid_map_pcl/src/GridMapPclLoader.cpp
@@ -197,9 +197,31 @@ double GridMapPclLoader::calculateElevationFromPointsInsideGridMapCell(
       return grid_map_pcl::calculateMeanOfPointPositions(cloud).z();
     });
 
-  double minClusterHeight = *(std::min_element(clusterHeights.begin(), clusterHeights.end()));
+  double height;
+  const int height_type = params_->get().gridMap_.height_type_;
+  // 0: Smallest value among the average values ​​of each cluster
+  if (height_type == 0) {
+    height = *(std::min_element(clusterHeights.begin(), clusterHeights.end()));
+  }
+  // 1: Mean value of the cluster with the most points
+  else if (height_type == 1) {
+    std::vector<int> clusterSizes(clusterClouds.size());
+    std::transform(
+      clusterClouds.begin(), clusterClouds.end(), clusterSizes.begin(),
+      [this](Pointcloud::ConstPtr cloud) -> int {return cloud->size();});
+    const std::vector<int>::iterator maxIt =
+      std::max_element(clusterSizes.begin(), clusterSizes.end());
+    const size_t maxIndex = std::distance(clusterSizes.begin(), maxIt);
+    height = clusterHeights[maxIndex];
+  } else {
+    throw std::invalid_argument(
+            "Invalid height type: " + std::to_string(height_type) +
+            "\nValid types are below" +
+            "\n0: Smallest value among the average values ​​of each cluster" +
+            "\n1: Mean value of the cluster with the most points");
+  }
 
-  return minClusterHeight;
+  return height;
 }
 
 GridMapPclLoader::Pointcloud::Ptr GridMapPclLoader::getPointcloudInsideGridMapCellBorder(

--- a/grid_map_pcl/src/GridMapPclLoader.cpp
+++ b/grid_map_pcl/src/GridMapPclLoader.cpp
@@ -205,10 +205,13 @@ double GridMapPclLoader::calculateElevationFromPointsInsideGridMapCell(
   }
   // 1: Mean value of the cluster with the most points
   else if (height_type == 1) {
+    const float min_height = *(std::min_element(clusterHeights.begin(), clusterHeights.end()));
     std::vector<int> clusterSizes(clusterClouds.size());
-    std::transform(
-      clusterClouds.begin(), clusterClouds.end(), clusterSizes.begin(),
-      [this](Pointcloud::ConstPtr cloud) -> int {return cloud->size();});
+    for (size_t i = 0; i < clusterClouds.size(); i++) {
+      clusterSizes[i] = clusterHeights[i] - min_height < params_->get().gridMap_.height_thresh_ ?
+        clusterClouds[i]->size() :
+        -1;
+    }
     const std::vector<int>::iterator maxIt =
       std::max_element(clusterSizes.begin(), clusterSizes.end());
     const size_t maxIndex = std::distance(clusterSizes.begin(), maxIt);

--- a/grid_map_pcl/src/PclLoaderParameters.cpp
+++ b/grid_map_pcl/src/PclLoaderParameters.cpp
@@ -61,6 +61,8 @@ void PclLoaderParameters::handleYamlNode(const YAML::Node & yamlNode)
     yamlNode[prefix]["grid_map"]["resolution"].as<double>();
   parameters_.gridMap_.minCloudPointsPerCell_ =
     yamlNode[prefix]["grid_map"]["min_num_points_per_cell"].as<int>();
+  parameters_.gridMap_.height_type_ =
+    yamlNode[prefix]["grid_map"]["height_type"].as<int>();
 
   parameters_.downsampling_.isDownsampleCloud_ =
     yamlNode[prefix]["downsampling"]["is_downsample_cloud"].as<bool>();

--- a/grid_map_pcl/src/PclLoaderParameters.cpp
+++ b/grid_map_pcl/src/PclLoaderParameters.cpp
@@ -63,6 +63,8 @@ void PclLoaderParameters::handleYamlNode(const YAML::Node & yamlNode)
     yamlNode[prefix]["grid_map"]["min_num_points_per_cell"].as<int>();
   parameters_.gridMap_.height_type_ =
     yamlNode[prefix]["grid_map"]["height_type"].as<int>();
+  parameters_.gridMap_.height_thresh_ =
+    yamlNode[prefix]["grid_map"]["height_thresh"].as<double>();
 
   parameters_.downsampling_.isDownsampleCloud_ =
     yamlNode[prefix]["downsampling"]["is_downsample_cloud"].as<bool>();


### PR DESCRIPTION
Thank you for the work.
I added the method to  use the mean value of the cluster with the most points as elevation value.
This method may be able to estimate more ground-like values.

0: Smallest value among the average values ​​of each cluster (current method)
![Screenshot from 2021-09-08 20-51-47](https://user-images.githubusercontent.com/39142679/132508417-98485cee-1a7b-4927-a769-006793e227c3.png)

1: Mean value of the cluster with the most points (new method)
(height_thresh is a parameter for this methods to reduce the influence of point clouds that exist in high locations such as ceilings.)
![Screenshot from 2021-09-08 21-21-42](https://user-images.githubusercontent.com/39142679/132508432-fea55f5e-56fc-4bae-b621-8fa784198511.png)
