### PR TITLE
Add explicit dependency on OpenCV

### DIFF
--- a/grid_map_cv/package.xml
+++ b/grid_map_cv/package.xml
@@ -15,6 +15,7 @@
   <depend>grid_map_core</depend>
   <depend>cv_bridge</depend>
   <depend>filters</depend>
+  <depend>libopencv-dev</depend>
 <!--   <test_depend>cmake_code_coverage</test_depend> -->
   <test_depend>gtest</test_depend>
   <export>


### PR DESCRIPTION
We noticed that opencv is not explicitly defined as dependency in grid-map-cv, although it is being used:

https://github.com/ANYbotics/grid_map/blob/794909ade22c3dae1d10384c9417d3ba90979d8e/grid_map_cv/CMakeLists.txt#L15-L18