### PR TITLE
[rolling] grid_map_pcl needs PCLConfig.cmake but not included in package.xml

### DIFF
--- a/grid_map_pcl/CHANGELOG.rst
+++ b/grid_map_pcl/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package grid_map_pcl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+unreleased (2021-06-24)
+------------------
+* Replaced pcl_ros dependency with PCL
+* Contributors: Matthew Young (Trimble Inc) 
+
 1.6.2 (2019-10-14)
 ------------------
 

--- a/grid_map_pcl/CMakeLists.txt
+++ b/grid_map_pcl/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(grid_map_cmake_helpers REQUIRED)
 find_package(grid_map_core REQUIRED)
 find_package(grid_map_msgs REQUIRED)
 find_package(grid_map_ros REQUIRED)
-find_package(pcl_ros REQUIRED)
+find_package(PCL REQUIRED) ## See ROS REP2000 for expected PCL version
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
 
@@ -16,6 +16,11 @@ if(OpenMP_FOUND)
   add_compile_options("${OpenMP_CXX_FLAGS}")
   add_definitions(-DGRID_MAP_PCL_OPENMP_FOUND=${OpenMP_FOUND})
 endif()
+
+# Add links to PCL definitons and directories
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
 
 grid_map_package()
 
@@ -31,7 +36,6 @@ set(dependencies
   grid_map_core
   grid_map_msgs
   grid_map_ros
-  pcl_ros
   rclcpp
   rcutils
 )
@@ -55,6 +59,7 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${OpenMP_CXX_LIBRARIES}
+  ${PCL_LIBRARIES}
   yaml-cpp
 )
 

--- a/grid_map_pcl/package.xml
+++ b/grid_map_pcl/package.xml
@@ -18,10 +18,10 @@
   <depend>grid_map_core</depend>
   <depend>grid_map_msgs</depend>
   <depend>grid_map_ros</depend>
-  <depend>pcl_ros</depend>
   <depend>rclcpp</depend>
   <depend>rcutils</depend>
   <depend>yaml-cpp</depend>
+  <depend>libpcl-all</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/grid_map_pcl/package.xml
+++ b/grid_map_pcl/package.xml
@@ -14,6 +14,7 @@
   
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>grid_map_cmake_helpers</build_depend>
+  <build_depend>libpcl-all-dev</build_depend>
 
   <depend>grid_map_core</depend>
   <depend>grid_map_msgs</depend>
@@ -21,7 +22,8 @@
   <depend>rclcpp</depend>
   <depend>rcutils</depend>
   <depend>yaml-cpp</depend>
-  <depend>libpcl-all</depend>
+  
+  <exec_depend>libpcl-all</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
In compile time, it needs PCLConfig.cmake for configuration, which is in libpcl-dev(in rosdep, it is defined as libpcl-all-dev)

On,
- Ubuntu 20.04
- Inside a Docker container Docker (ros:foxy)
- current HEAD on foxy_devel
,

I failed to build grid_map_pcl like below:

```
root@cb0f1bcd71a1:/_build_ws# colcon build
Starting >>> grid_map_cmake_helpers
--- stderr: grid_map_cmake_helpers
CMake Error at CMakeLists.txt:5 (find_package):
  By not providing "Findament_cmake_core.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "ament_cmake_core", but CMake did not find one.

  Could not find a package configuration file provided by "ament_cmake_core"
  with any of the following names:

    ament_cmake_coreConfig.cmake
    ament_cmake_core-config.cmake

  Add the installation prefix of "ament_cmake_core" to CMAKE_PREFIX_PATH or
  set "ament_cmake_core_DIR" to a directory containing one of the above
  files.  If "ament_cmake_core" provides a separate development package or
  SDK, be sure it has been installed.


```