### PR TITLE
fix: build error on jammy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
               $UNDERLAY_WS/ros2_dependencies.repos
             cd $UNDERLAY_WS && vcs import src < ros2_dependencies.repos
             DEBIAN_FRONTEND=noninteractive  rosdep install -y --ignore-src \
-              --skip-keys "pybind11_vendor" --skip-keys "ompl" --skip-keys "slam_toolbox" --from-paths src
+              --skip-keys "gazebo_ros_pkgs pybind11_vendor ompl slam_toolbox" --from-paths src
             MAKEFLAGS="-j4 -l1" colcon build --symlink-install --executor sequential --packages-up-to nav2_costmap_2d
             source $UNDERLAY_WS/install/setup.bash
             cd $OVERLAY_WS && DEBIAN_FRONTEND=noninteractive rosdep install -y --ignore-src --from-paths src

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
               --skip-keys "gazebo_ros_pkgs pybind11_vendor ompl slam_toolbox" --from-paths src
             MAKEFLAGS="-j4 -l1" colcon build --symlink-install --executor sequential --packages-up-to nav2_costmap_2d
             source $UNDERLAY_WS/install/setup.bash
-            cd $OVERLAY_WS && DEBIAN_FRONTEND=noninteractive rosdep install -y --ignore-src --from-paths src
+            cd $OVERLAY_WS && DEBIAN_FRONTEND=noninteractive rosdep install -y --ignore-src --from-paths src --skip-keys "octomap_server"
       - run:
           name: Debug Build
           command: |

--- a/grid_map/package.xml
+++ b/grid_map/package.xml
@@ -11,12 +11,15 @@
   <url type="bugtracker">http://github.com/anybotics/grid_map/issues</url>
   <author email="pfankhauser@anybotics.com">Péter Fankhauser</author>
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>grid_map_cmake_helpers</exec_depend>
   <exec_depend>grid_map_core</exec_depend>
+  <exec_depend>grid_map_costmap_2d</exec_depend>
   <exec_depend>grid_map_cv</exec_depend>
   <exec_depend>grid_map_demos</exec_depend>
   <exec_depend>grid_map_filters</exec_depend>
   <exec_depend>grid_map_loader</exec_depend>
   <exec_depend>grid_map_msgs</exec_depend>
+  <exec_depend>grid_map_octomap</exec_depend>
   <exec_depend>grid_map_pcl</exec_depend>
   <exec_depend>grid_map_ros</exec_depend>
   <exec_depend>grid_map_rviz_plugin</exec_depend>

--- a/grid_map/package.xml
+++ b/grid_map/package.xml
@@ -12,16 +12,16 @@
   <author email="pfankhauser@anybotics.com">Péter Fankhauser</author>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <exec_depend>grid_map_core</exec_depend>
-  <exec_depend>grid_map_ros</exec_depend>
   <exec_depend>grid_map_cv</exec_depend>
-  <exec_depend>grid_map_msgs</exec_depend>
-  <exec_depend>grid_map_filters</exec_depend>
-  <exec_depend>grid_map_visualization</exec_depend>
-  <exec_depend>grid_map_rviz_plugin</exec_depend>
-  <exec_depend>grid_map_loader</exec_depend>
   <exec_depend>grid_map_demos</exec_depend>
-  <exec_depend>grid_map_sdf</exec_depend>
+  <exec_depend>grid_map_filters</exec_depend>
+  <exec_depend>grid_map_loader</exec_depend>
+  <exec_depend>grid_map_msgs</exec_depend>
   <exec_depend>grid_map_pcl</exec_depend>
+  <exec_depend>grid_map_ros</exec_depend>
+  <exec_depend>grid_map_rviz_plugin</exec_depend>
+  <exec_depend>grid_map_sdf</exec_depend>
+  <exec_depend>grid_map_visualization</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/grid_map/package.xml
+++ b/grid_map/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>grid_map_rviz_plugin</exec_depend>
   <exec_depend>grid_map_loader</exec_depend>
   <exec_depend>grid_map_demos</exec_depend>
+  <exec_depend>grid_map_sdf</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/grid_map/package.xml
+++ b/grid_map/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>grid_map_loader</exec_depend>
   <exec_depend>grid_map_demos</exec_depend>
   <exec_depend>grid_map_sdf</exec_depend>
+  <exec_depend>grid_map_pcl</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/grid_map_core/CMakeLists.txt
+++ b/grid_map_core/CMakeLists.txt
@@ -97,7 +97,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
   ament_lint_auto_find_test_dependencies()

--- a/grid_map_cv/CMakeLists.txt
+++ b/grid_map_cv/CMakeLists.txt
@@ -96,7 +96,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
   ament_lint_auto_find_test_dependencies()

--- a/grid_map_demos/CMakeLists.txt
+++ b/grid_map_demos/CMakeLists.txt
@@ -254,7 +254,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
   ament_lint_auto_find_test_dependencies()

--- a/grid_map_filters/CMakeLists.txt
+++ b/grid_map_filters/CMakeLists.txt
@@ -142,7 +142,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
   ament_lint_auto_find_test_dependencies()

--- a/grid_map_filters/src/ColorBlendingFilter.cpp
+++ b/grid_map_filters/src/ColorBlendingFilter.cpp
@@ -120,6 +120,7 @@ bool ColorBlendingFilter<T>::update(const T & mapIn, T & mapOut)
       backgroundColor = color.array();
       colorValueToVector(foreground(i), color);
       foregroundColor = color.array();
+      outputColor = Eigen::Array3f::Zero();
 
       switch (blendMode_) {
         case BlendModes::Normal:

--- a/grid_map_loader/CMakeLists.txt
+++ b/grid_map_loader/CMakeLists.txt
@@ -84,7 +84,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
   ament_lint_auto_find_test_dependencies()

--- a/grid_map_octomap/CMakeLists.txt
+++ b/grid_map_octomap/CMakeLists.txt
@@ -71,7 +71,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
   ament_lint_auto_find_test_dependencies()

--- a/grid_map_pcl/CMakeLists.txt
+++ b/grid_map_pcl/CMakeLists.txt
@@ -132,7 +132,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
   ament_lint_auto_find_test_dependencies()

--- a/grid_map_pcl/src/GridMapPclLoader.cpp
+++ b/grid_map_pcl/src/GridMapPclLoader.cpp
@@ -17,6 +17,8 @@
 #include <omp.h>
 #endif
 
+#include <pcl/common/io.h>
+
 #include <rclcpp/rclcpp.hpp>
 
 #include "grid_map_core/GridMapMath.hpp"

--- a/grid_map_pcl/src/helpers.cpp
+++ b/grid_map_pcl/src/helpers.cpp
@@ -34,9 +34,7 @@ namespace grid_map_pcl
 
 void setVerbosityLevelToDebugIfFlagSet(rclcpp::Node::SharedPtr & node)
 {
-  bool isSetVerbosityLevelToDebug;
-  node->declare_parameter("set_verbosity_to_debug", false);
-  node->get_parameter("set_verbosity_to_debug", isSetVerbosityLevelToDebug);
+  bool isSetVerbosityLevelToDebug = node->declare_parameter("set_verbosity_to_debug", false);
 
   if (!isSetVerbosityLevelToDebug) {
     return;

--- a/grid_map_ros/CMakeLists.txt
+++ b/grid_map_ros/CMakeLists.txt
@@ -102,7 +102,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
   ament_lint_auto_find_test_dependencies()

--- a/grid_map_rviz_plugin/CMakeLists.txt
+++ b/grid_map_rviz_plugin/CMakeLists.txt
@@ -124,7 +124,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
 endif()

--- a/grid_map_sdf/CMakeLists.txt
+++ b/grid_map_sdf/CMakeLists.txt
@@ -89,7 +89,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
   ament_lint_auto_find_test_dependencies()

--- a/grid_map_sdf/CMakeLists.txt
+++ b/grid_map_sdf/CMakeLists.txt
@@ -23,7 +23,9 @@ grid_map_package()
 ## Specify additional locations of header files
 include_directories(
   include
-  ${EIGEN3_INCLUDE_DIR}
+  SYSTEM
+    ${EIGEN3_INCLUDE_DIR}
+    ${PCL_INCLUDE_DIRS}
 )
 
 set(dependencies

--- a/grid_map_visualization/CMakeLists.txt
+++ b/grid_map_visualization/CMakeLists.txt
@@ -112,7 +112,7 @@ if(BUILD_TESTING)
     # run cpplint without copyright filter
     find_package(ament_cmake_cpplint)
     ament_cpplint(
-      FILTERS -legal/copyright
+      FILTERS -legal/copyright -build/include_order
     )
   endif()
   ament_lint_auto_find_test_dependencies()


### PR DESCRIPTION
fix build error as below on jammy
```
/usr/include/eigen3/Eigen/src/Core/functors/AssignmentFunctors.h:24:102: error: ‘outputColor.Eigen::Array<float, 3, 1, 0, 3, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Array<float, 3, 1, 0, 3, 1> >::m_storage.Eigen::DenseStorage<float, 3, 3, 1, 0>::m_data.Eigen::internal::plain_array<float, 3, 0, 0>::array[2]’ may be used uninitialized [-Werror=maybe-uninitialized]
   24 |   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void assignCoeff(DstScalar& a, const SrcScalar& b) const { a = b; }
      |                                                                                                    ~~^~~
/home/daisuke/workspace/sandbox_ws/src/grid_map/grid_map_filters/src/ColorBlendingFilter.cpp: In member function ‘bool grid_map::ColorBlendingFilter<T>::update(const T&, T&) [with T = grid_map::GridMap]’:
/home/daisuke/workspace/sandbox_ws/src/grid_map/grid_map_filters/src/ColorBlendingFilter.cpp:117:56: note: ‘outputColor’ declared here
  117 |       Eigen::Array3f backgroundColor, foregroundColor, outputColor;
```