### PR TITLE
fixed building error with g++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0

### DIFF
--- a/grid_map_pcl/include/grid_map_pcl/helpers.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/helpers.hpp
@@ -10,6 +10,7 @@
 #define GRID_MAP_PCL__HELPERS_HPP_
 
 #include <pcl/common/common.h>
+#include <pcl/common/io.h>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 #include <chrono>

--- a/grid_map_pcl/src/helpers.cpp
+++ b/grid_map_pcl/src/helpers.cpp
@@ -34,7 +34,7 @@ namespace grid_map_pcl
 
 void setVerbosityLevelToDebugIfFlagSet(rclcpp::Node::SharedPtr & node)
 {
-  bool isSetVerbosityLevelToDebug;
+  bool isSetVerbosityLevelToDebug = false;
   node->declare_parameter("set_verbosity_to_debug", false);
   node->get_parameter("set_verbosity_to_debug", isSetVerbosityLevelToDebug);
 

--- a/grid_map_pcl/src/helpers.cpp
+++ b/grid_map_pcl/src/helpers.cpp
@@ -34,7 +34,7 @@ namespace grid_map_pcl
 
 void setVerbosityLevelToDebugIfFlagSet(rclcpp::Node::SharedPtr & node)
 {
-  bool isSetVerbosityLevelToDebug = false;
+  bool isSetVerbosityLevelToDebug{false};
   node->declare_parameter("set_verbosity_to_debug", false);
   node->get_parameter("set_verbosity_to_debug", isSetVerbosityLevelToDebug);
 


### PR DESCRIPTION
I have met following building error on Ubuntu-18.04(WSL2) with g++ version of 7.5.0.
1. Missing type declaration of `copyPointCloud` in `GridMapPclLoader.cpp` scope:
```
grid_map/grid_map_pcl/src/GridMapPclLoader.cpp: In member function ‘void grid_map::GridMapPclLoader::setRawInputCloud(pcl::PointCloud<pcl::PointXYZ>::ConstPtr)’:
grid_map/grid_map_pcl/src/GridMapPclLoader.cpp:62:8: error: ‘copyPointCloud’ is not a member of ‘pcl’
	   pcl::copyPointCloud(*rawInputCloud, *temp);
```
2. The compiler claims that a variable may be used uninitialized.
```
grid_map/grid_map_pcl/src/helpers.cpp:41:3: error: ‘isSetVerbosityLevelToDebug’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
	   if (!isSetVerbosityLevelToDebug) {
```