### PR TITLE
Do not iterate over the map when size is 0

### DIFF
--- a/grid_map_core/src/iterators/GridMapIterator.cpp
+++ b/grid_map_core/src/iterators/GridMapIterator.cpp
@@ -17,7 +17,7 @@ GridMapIterator::GridMapIterator(const grid_map::GridMap& gridMap)
   startIndex_ = gridMap.getStartIndex();
   linearSize_ = size_.prod();
   linearIndex_ = 0;
-  isPastEnd_ = false;
+  isPastEnd_ = linearSize_ > linearIndex_ ? false : true;
 }
 
 GridMapIterator::GridMapIterator(const GridMapIterator* other)

--- a/grid_map_core/test/GridMapIteratorTest.cpp
+++ b/grid_map_core/test/GridMapIteratorTest.cpp
@@ -61,3 +61,13 @@ TEST(GridMapIterator, LinearIndex)
   EXPECT_TRUE(iterator.isPastEnd());
   EXPECT_TRUE((map["layer"].array() == 1.0f).all());
 }
+
+TEST(GridMapIterator, GeometryIsNotSet)
+{
+  grid_map::GridMap map;
+  grid_map::GridMapIterator iterator(map);
+
+  // If geometry of GridMap has not been set, bufferSize is by default (0,0).
+  // We cannot read GridMap's data as it's empty so GridMapIterator.isPastEnd() should return "true".
+  EXPECT_TRUE(iterator.isPastEnd());
+}


### PR DESCRIPTION
Hey,

I have noticed small bug within GridMapIterator. There are two situations in which GridMap object is empty (size is 0,0):
- When geometry of GridMap is not set, so it's by default (0,0)
- Due to very small length values, so size may be rounded to (0,0) https://github.com/ANYbotics/grid_map/blob/master/grid_map_core/src/GridMap.cpp#L51

When using GridMapIterator as shown in README.md and demos https://github.com/ANYbotics/grid_map/blob/master/grid_map_demos/src/IteratorsDemo.cpp#L58, first iteration is always valid as `isPastEnd_` variable is `false` regardless of the GridMap's size https://github.com/ANYbotics/grid_map/blob/master/grid_map_core/src/iterators/GridMapIterator.cpp#L20. Accessing empty GridMap leads to exception which crashes whole application as currently it's not catched or even documented.

I have added validation in GridMapIterator constructor which ensures GridMap is accessible. I have also added simple test to check if `isPastEnd_` variable initializes with `true` value when passed GridMap is empty.
