### PR TITLE
adds overloads for faster toImage and addLayerToImage

### DIFF
--- a/grid_map_cv/CMakeLists.txt
+++ b/grid_map_cv/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(OpenCV REQUIRED
   COMPONENTS
+  opencv_core
   opencv_photo
 )
 

--- a/grid_map_demos/src/opencv_demo_node.cpp
+++ b/grid_map_demos/src/opencv_demo_node.cpp
@@ -42,15 +42,14 @@ int main(int argc, char** argv)
   for (grid_map::PolygonIterator iterator(map, polygon); !iterator.isPastEnd(); ++iterator) {
     map.at("original", *iterator) = 0.3;
   }
-
   // Convert to CV image.
   cv::Mat originalImage;
   if (useTransparency) {
     // Note: The template parameters have to be set based on your encoding
     // of the image. For 8-bit images use `unsigned char`.
-    GridMapCvConverter::toImage<unsigned short, 4>(map, "original", CV_16UC4, 0.0, 0.3, originalImage);
+    GridMapCvConverter::toImage<unsigned short, 4>(map, "original", CV_16UC4, useTransparency, 0.0, 0.3, originalImage);
   } else {
-    GridMapCvConverter::toImage<unsigned short, 1>(map, "original", CV_16UC1, 0.0, 0.3, originalImage);
+    GridMapCvConverter::toImage<unsigned short, 1>(map, "original", CV_16UC1, useTransparency, 0.0, 0.3, originalImage);
   }
 
   // Create OpenCV window.
@@ -77,7 +76,7 @@ int main(int argc, char** argv)
     if (useTransparency) {
       GridMapCvConverter::addLayerFromImage<unsigned short, 4>(modifiedImage, "elevation", map, 0.0, 0.3, 0.3);
     } else {
-      GridMapCvConverter::addLayerFromImage<unsigned short, 1>(modifiedImage, "elevation", map, 0.0, 0.3);
+      GridMapCvConverter::addLayerFromImage<unsigned short, 1>(modifiedImage, "elevation", map, useTransparency, 0.0, 0.3, 0.3);
     }
 
     // Publish grid map.


### PR DESCRIPTION
Addresses discussion in issue #359.

Overload created by use of boolean isAlpha, with the faster path available for images without transparency, when isAlpha is true, the slow path is used.
static bool addLayerFromImage(const cv::Mat& image, const std::string& layer,
                                grid_map::GridMap& gridMap, **bool isAlpha**, const float lowerValue,
                                const float upperValue, const double alphaThreshold)
static bool toImage(const grid_map::GridMap& gridMap, const std::string& layer,
                      const int encoding, **bool isAlpha**, const float lowerValue, const float upperValue,
                      cv::Mat& image)