### PR TITLE
Add method for loading a color layer from a textured mesh

### DIFF
--- a/grid_map_pcl/include/grid_map_pcl/GridMapPclConverter.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/GridMapPclConverter.hpp
@@ -60,6 +60,16 @@ class GridMapPclConverter {
    */
   static bool addLayerFromPolygonMesh(const pcl::PolygonMesh& mesh, const std::string& layer, grid_map::GridMap& gridMap);
 
+  /*!
+   * Adds a color layer with data from a polygon mesh. The mesh is ray traced from
+   * above (negative z-Direction).
+   * @param[in] mesh the mesh to be added. It can only consist of triangles!
+   * @param[in] layer the layer that is filled with the mesh data.
+   * @param[out] gridMap the grid map to be populated.
+   * @return true if successful, false otherwise.
+   */
+  static bool addColorLayerFromPolygonMesh(const pcl::PolygonMesh& mesh, const std::string& layer, grid_map::GridMap& gridMap);
+
  private:
   static bool rayTriangleIntersect(const Eigen::Vector3f& point, const Eigen::Vector3f& ray, const Eigen::Matrix3f& triangleVertices,
                                    Eigen::Vector3f& intersectionPoint);


### PR DESCRIPTION
**Problem Description**
When loading a gridmap from a polygon mesh, only the geometry was being read on the grid map.

This commit extends the gird map pcl coverter for loading a color layer from a textured mesh

**Testing**
A mesh can be read and added with a color layer with the two sequences
```
  grid_map::GridMapPclConverter::addLayerFromPolygonMesh(mesh, "elevation", grid_map_);
  grid_map::GridMapPclConverter::addColorLayerFromPolygonMesh(mesh, "color", grid_map_);
```

![gridmap-mesh](https://user-images.githubusercontent.com/5248102/189654095-e80ae104-dc00-4a7e-bc52-b370b42703a8.gif)

