### PR TITLE
[foxy-devel]use rosbag2_storage::StorageOptions instead of rosbag2_cpp::StorageOptions

### DIFF
--- a/grid_map_ros/src/GridMapRosConverter.cpp
+++ b/grid_map_ros/src/GridMapRosConverter.cpp
@@ -667,7 +667,7 @@ bool GridMapRosConverter::saveToBag(
   rclcpp::Serialization<grid_map_msgs::msg::GridMap> serialization;
   serialization.serialize_message(message.get(), &serialized_msg);
 
-  rosbag2_cpp::StorageOptions storage_options;
+  rosbag2_storage::StorageOptions storage_options;
   storage_options.uri = pathToBag;
   storage_options.storage_id = "sqlite3";
 
@@ -703,7 +703,7 @@ bool GridMapRosConverter::loadFromBag(
   const std::string & pathToBag, const std::string & topic,
   grid_map::GridMap & gridMap)
 {
-  rosbag2_cpp::StorageOptions storage_options;
+  rosbag2_storage::StorageOptions storage_options;
   storage_options.uri = pathToBag;
   storage_options.storage_id = "sqlite3";
 


### PR DESCRIPTION
rosbag2_cpp::StorageOptions is deprecated and it triggers a hard break of building error now.
```shell
autowareauto/src/external/grid_map/grid_map_ros/src/GridMapRosConverter.cpp:670:16: error: ‘StorageOptions’ is not a member of ‘rosbag2_cpp’
  670 |   rosbag2_cpp::StorageOptions storage_options;
      |                ^~~~~~~~~~~~~~
...
autowareauto/src/external/grid_map/grid_map_ros/src/GridMapRosConverter.cpp:706:16: error: ‘StorageOptions’ is not a member of ‘rosbag2_cpp’
  706 |   rosbag2_cpp::StorageOptions storage_options;
      |                ^~~~~~~~~~~~~~
```
I have changed them to deserved `rosbag2_storage::StorageOptions`.