### PR TITLE
Do not expose include directory as interface

### DIFF
--- a/grid_map_loader/CMakeLists.txt
+++ b/grid_map_loader/CMakeLists.txt
@@ -37,8 +37,9 @@ catkin_package(
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
-include_directories(
-  include
+target_include_directories(${PROJECT_NAME}
+  PRIVATE
+    include
   SYSTEM
     ${catkin_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIR}


### PR DESCRIPTION
This was noticed when building this library using Nix package manager: https://github.com/lopsided98/nix-ros-overlay/issues/305