### PR TITLE
Update ros2_dependencies.repos

### DIFF
--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -1,5 +1,5 @@
 repositories:
-  ros-planning/navigation2:
+  ros-perception/perception_pcl:
     type: git
-    url: https://github.com/ros-planning/navigation2.git
-    version: main
+    url: https://github.com/ros-perception/perception_pcl.git
+    version: ros2


### PR DESCRIPTION
Fixes an which comes apprears during ````colcon build --symlink-install --packages-up-to pcl_ros``` which thre me ```Package 'pcl_ros' specified with --packages-up-to was not found``` (same issue as in [old Issue](https://github.com/ANYbotics/grid_map/issues/371)