### PR TITLE
Stop using deprecated CMAKE_COMPILER_IS_GNUCXX

### DIFF
--- a/grid_map_cmake_helpers/cmake/grid_map_package.cmake
+++ b/grid_map_cmake_helpers/cmake/grid_map_package.cmake
@@ -17,7 +17,7 @@ macro(grid_map_package)
     set(CMAKE_CXX_STANDARD 17)
   endif()
 
-  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC)
   endif()
 

--- a/grid_map_demos/CMakeLists.txt
+++ b/grid_map_demos/CMakeLists.txt
@@ -201,7 +201,7 @@ set(targets_list
 )
 
 foreach(target ${targets_list})
-  if(CMAKE_COMPILER_IS_GNUCXX)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     target_compile_options(${target} PRIVATE "SHELL:--param ggc-min-expand=1")
     target_compile_options(${target} PRIVATE "SHELL:--param ggc-min-heapsize=32768")
   endif()

--- a/grid_map_filters/CMakeLists.txt
+++ b/grid_map_filters/CMakeLists.txt
@@ -87,7 +87,7 @@ foreach(lib_name ${filter_libs})
     ${dependencies}
   )
 
-  if(CMAKE_COMPILER_IS_GNUCXX)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     target_compile_options(${lib_name} PRIVATE "SHELL:--param ggc-min-expand=1")
     target_compile_options(${lib_name} PRIVATE "SHELL:--param ggc-min-heapsize=32768")
   endif()


### PR DESCRIPTION
* Switch to CMAKE_CXX_COMPILER_ID
* https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html
* https://cmake.org/cmake/help/latest/variable/CMAKE_COMPILER_IS_GNUCXX.html#cmake-compiler-is-gnucxx