### PR TITLE
ci(Mergify): Add initial config

### DIFF
--- a/.github/.mergify.yml
+++ b/.github/.mergify.yml
@@ -1,0 +1,36 @@
+---
+pull_request_rules:
+  - name: backport to iron at reviewers discretion
+    conditions:
+      - base=rolling
+      - label=backport-iron
+    actions:
+      backport:
+        branches:
+          - iron
+
+  - name: backport to humble at reviewers discretion
+    conditions:
+      - base=rolling
+      - label=backport-humble
+    actions:
+      backport:
+        branches:
+          - humble
+
+  - name: delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch:
+
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+      - author!=mergify
+    actions:
+      comment:
+        message: This pull request is in conflict. Could you fix it @{{author}}?
+
+# TODO enable automatic merge of backports
+# https://docs.mergify.com/workflow/actions/backport/#combining-automatic-merge


### PR DESCRIPTION
# Purpose

Add a Mergify CI file to help grid_map maintainers out with automatic features such as backporting. This reduces the time per pull-request needed to maintain multiple branches. Easier review and backport helps promote smaller PR's that are easier to review or revert. 

## Details

* For backport to iron and humble
* Asking to fix conflicts
* Deleting head branch after merge

## Demo

1. Ask for a backport: https://github.com/Ryanf55/grid_map/pull/2#issuecomment-1925889673
2. Mergify replies that it created the backport: https://github.com/Ryanf55/grid_map/pull/2#issuecomment-1925889801
3. You can see it automatically creates the backport: https://github.com/Ryanf55/grid_map/pull/3

## Future work 

In the future, once we gain trust, I can add the automatic merge of backports as long as they pass CI. We should probably integrate an ABI checker to the repo before doing that. For now, reviewers will be required to do the final merge.
