### PR TITLE
Use ament_export_targets in grid_map_costmap_2d

### DIFF
--- a/grid_map_costmap_2d/CMakeLists.txt
+++ b/grid_map_costmap_2d/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(grid_map_cmake_helpers REQUIRED)
 find_package(grid_map_core REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
-
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
@@ -23,7 +22,7 @@ set(dependencies
   tf2_geometry_msgs
 )
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} INTERFACE
   include/grid_map_costmap_2d/costmap_2d_converter.hpp
   include/grid_map_costmap_2d/grid_map_costmap_2d.hpp
 )
@@ -31,7 +30,7 @@ add_library(${PROJECT_NAME}
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME}
-  PUBLIC
+  INTERFACE
     grid_map_core::grid_map_core
     ${geometry_msgs_TARGETS}
     ${tf2_geometry_msgs_TARGETS}
@@ -40,7 +39,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
-  PUBLIC
+  INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )

--- a/grid_map_costmap_2d/CMakeLists.txt
+++ b/grid_map_costmap_2d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 project(grid_map_costmap_2d)
 
 ## Find ament_cmake macros and libraries
@@ -7,22 +7,13 @@ find_package(grid_map_cmake_helpers REQUIRED)
 find_package(grid_map_core REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
+
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
 find_package(Eigen3 REQUIRED)
 
 grid_map_package()
-
-## Specify additional locations of header files
-include_directories(
-  include
-  SYSTEM
-    ${EIGEN3_INCLUDE_DIR}
-    ${grid_map_core_INCLUDE_DIRS}
-    ${nav2_costmap_2d_INCLUDE_DIRS}
-    ${geometry_msgs_INCLUDE_DIRS}
-)
 
 set(dependencies
   grid_map_core
@@ -32,13 +23,44 @@ set(dependencies
   tf2_geometry_msgs
 )
 
+add_library(${PROJECT_NAME}
+  include/grid_map_costmap_2d/costmap_2d_converter.hpp
+  include/grid_map_costmap_2d/grid_map_costmap_2d.hpp
+)
+
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    grid_map_core::grid_map_core
+    ${geometry_msgs_TARGETS}
+    ${tf2_geometry_msgs_TARGETS}
+    nav2_costmap_2d::nav2_costmap_2d_core
+    tf2_ros::tf2_ros
+)
+
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+
 #############
 ## Install ##
 #############
 
+# Mark library for installation
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
 # Mark cpp header files for installation
 install(
-  DIRECTORY include/${PROJECT_NAME}/
+  DIRECTORY include/
   DESTINATION include/${PROJECT_NAME}
   FILES_MATCHING PATTERN "*.hpp"
 )
@@ -77,6 +99,6 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dependencies})
 ament_package()

--- a/grid_map_costmap_2d/test/CMakeLists.txt
+++ b/grid_map_costmap_2d/test/CMakeLists.txt
@@ -15,4 +15,3 @@ target_link_libraries(costmap-2d-ros-test
   ${PROJECT_NAME}::${PROJECT_NAME}
 )
 
-

--- a/grid_map_costmap_2d/test/CMakeLists.txt
+++ b/grid_map_costmap_2d/test/CMakeLists.txt
@@ -3,14 +3,16 @@ ament_add_gtest(${PROJECT_NAME}-test
   test_costmap_2d_converter.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME}-test
-  ${dependencies}
+target_link_libraries(${PROJECT_NAME}-test
+  ${PROJECT_NAME}::${PROJECT_NAME}
 )
 
 ament_add_gtest(costmap-2d-ros-test
   test_costmap_2d_ros.cpp
 )
 
-ament_target_dependencies(costmap-2d-ros-test
-  ${dependencies}
+target_link_libraries(costmap-2d-ros-test
+  ${PROJECT_NAME}::${PROJECT_NAME}
 )
+
+


### PR DESCRIPTION
# Purpose

* Link to exported namespace targets when possible
* Use ament_export_libraries
* Relates to #403 

# Dependencies

* https://github.com/ros-planning/navigation2/pull/4112