### PR TITLE
Bugfix use old style include directories for filters

### DIFF
--- a/grid_map_cv/CMakeLists.txt
+++ b/grid_map_cv/CMakeLists.txt
@@ -52,6 +52,12 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   ${sensor_msgs_TARGETS}
 )
 
+# Filters does not expose targets (yet)
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    ${filters_INCLUDE_DIRS}
+)
+
 #############
 ## Install ##
 #############

--- a/grid_map_cv/CMakeLists.txt
+++ b/grid_map_cv/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 )
 
 # Filters does not expose targets (yet)
+# https://github.com/ros/filters/pull/70
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     ${filters_INCLUDE_DIRS}


### PR DESCRIPTION
# Purpose

Use old-style CMake variables as a patch till this upstream issue makes it into humble binaries: https://github.com/ros/filters/pull/70

# Cause

https://github.com/ANYbotics/grid_map/pull/404/files#diff-217de7f0d7eec88dce2cada8716bd30748cf9ad20d1211c56501a2acb56666bbL28

This PR forgot to add the include directories from `filters`, probably because there were no targets. I'm not sure how it builds on rolling and not humble. This patch can be replaced with a proper `target_link_libraries` call soon. 

# Effect

It's blocking CI from passing in this PR: https://github.com/ANYbotics/grid_map/actions/runs/7943206475/job/21687293385?pr=440#step:6:25

# Upstream variables
```
$ cat /opt/ros/rolling/share/filters/cmake/ament_cmake_export_include_directories-extras.cmake 
# generated from ament_cmake_export_include_directories/cmake/ament_cmake_export_include_directories-extras.cmake.in

set(_exported_include_dirs "${filters_DIR}/../../../include")

# append include directories to filters_INCLUDE_DIRS
# warn about not existing paths
if(NOT _exported_include_dirs STREQUAL "")
  find_package(ament_cmake_core QUIET REQUIRED)
  foreach(_exported_include_dir ${_exported_include_dirs})
    if(NOT IS_DIRECTORY "${_exported_include_dir}")
      message(WARNING "Package 'filters' exports the include directory '${_exported_include_dir}' which doesn't exist")
    endif()
    normalize_path(_exported_include_dir "${_exported_include_dir}")
    list(APPEND filters_INCLUDE_DIRS "${_exported_include_dir}")
  endforeach()
endif()
```

You can see the variable we need to use is `filters_INCLUDE_DIRS`


