### PR TITLE
Fix nav2_costmap_2d linkage

### DIFF
--- a/grid_map_costmap_2d/CMakeLists.txt
+++ b/grid_map_costmap_2d/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(grid_map_cmake_helpers REQUIRED)
 find_package(grid_map_core REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
+find_package(rclcpp REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
@@ -34,9 +35,9 @@ target_link_libraries(${PROJECT_NAME}
     grid_map_core::grid_map_core
     ${geometry_msgs_TARGETS}
     ${tf2_geometry_msgs_TARGETS}
-    nav2_costmap_2d::nav2_costmap_2d_core
     tf2_ros::tf2_ros
 )
+ament_target_dependencies(${PROJECT_NAME} INTERFACE nav2_costmap_2d)
 
 target_include_directories(${PROJECT_NAME}
   INTERFACE

--- a/grid_map_costmap_2d/test/CMakeLists.txt
+++ b/grid_map_costmap_2d/test/CMakeLists.txt
@@ -5,6 +5,8 @@ ament_add_gtest(${PROJECT_NAME}-test
 
 target_link_libraries(${PROJECT_NAME}-test
   ${PROJECT_NAME}::${PROJECT_NAME}
+  tf2_ros::tf2_ros
+  rclcpp::rclcpp
 )
 
 ament_add_gtest(costmap-2d-ros-test


### PR DESCRIPTION
# Purpose

* Upstream nav2 didn't backport the dependencies
* Many dependencies were unlinked, and relied on transitively

# Ticket

Relates to https://github.com/ANYbotics/grid_map/issues/450

## Instructions

* source /opt/ros/iron/setup.bash
*  colcon build --packages-up-to grid_map_costmap_2d

## Logs

```bash
Starting >>> grid_map_costmap_2d
--- stderr: grid_map_costmap_2d                             
In file included from /opt/ros/iron/include/rclcpp_lifecycle/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp:20,
                 from /opt/ros/iron/include/rclcpp_lifecycle/rclcpp_lifecycle/lifecycle_node.hpp:89,
                 from /opt/ros/iron/include/nav2_costmap_2d/costmap_2d_publisher.hpp:46,
                 from /opt/ros/iron/include/nav2_costmap_2d/costmap_2d_ros.hpp:48,
                 from /home/ryan/Dev/ros2_ws/src/grid_map/grid_map_costmap_2d/test/test_costmap_2d_ros.hpp:23,
                 from /home/ryan/Dev/ros2_ws/src/grid_map/grid_map_costmap_2d/test/test_costmap_2d_ros.cpp:17:
/opt/ros/iron/include/rclcpp_lifecycle/rclcpp_lifecycle/state.hpp:21:10: fatal error: rcl_lifecycle/data_types.h: No such file or directory
   21 | #include "rcl_lifecycle/data_types.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [test/CMakeFiles/costmap-2d-ros-test.dir/build.make:76: test/CMakeFiles/costmap-2d-ros-test.dir/test_costmap_2d_ros.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:230: test/CMakeFiles/costmap-2d-ros-test.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
In file included from /opt/ros/iron/include/rclcpp_lifecycle/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp:20,
                 from /opt/ros/iron/include/rclcpp_lifecycle/rclcpp_lifecycle/lifecycle_node.hpp:89,
                 from /opt/ros/iron/include/nav2_costmap_2d/costmap_2d_publisher.hpp:46,
                 from /opt/ros/iron/include/nav2_costmap_2d/costmap_2d_ros.hpp:48,
                 from /home/ryan/Dev/ros2_ws/src/grid_map/grid_map_costmap_2d/include/grid_map_costmap_2d/costmap_2d_converter.hpp:22,
                 from /home/ryan/Dev/ros2_ws/src/grid_map/grid_map_costmap_2d/include/grid_map_costmap_2d/grid_map_costmap_2d.hpp:13,
                 from /home/ryan/Dev/ros2_ws/src/grid_map/grid_map_costmap_2d/test/test_costmap_2d_converter.cpp:18:
/opt/ros/iron/include/rclcpp_lifecycle/rclcpp_lifecycle/state.hpp:21:10: fatal error: rcl_lifecycle/data_types.h: No such file or directory
   21 | #include "rcl_lifecycle/data_types.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [test/CMakeFiles/grid_map_costmap_2d-test.dir/build.make:90: test/CMakeFiles/grid_map_costmap_2d-test.dir/test_costmap_2d_converter.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:202: test/CMakeFiles/grid_map_costmap_2d-test.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< grid_map_costmap_2d [0.36s, exited with code 2]
```