### PR TITLE
build: treat several build issues on rolling 

### DIFF
--- a/.github/workflows/colcon.yaml
+++ b/.github/workflows/colcon.yaml
@@ -32,7 +32,7 @@ jobs:
         apt update
         rosdep update
         source /opt/ros/${{matrix.config.rosdistro}}/setup.bash
-        rosdep install --from-paths src --ignore-src -y --skip-keys "slam_toolbox turtlebot3_gazebo gazebo_ros_pkgs"
+        rosdep install --from-paths src --ignore-src -y --skip-keys "slam_toolbox turtlebot3_gazebo gazebo_ros_pkgs octomap_server"
       shell: bash
     - name: Colcon Build (Release)
       run: |

--- a/grid_map_core/test/EigenPluginsTest.cpp
+++ b/grid_map_core/test/EigenPluginsTest.cpp
@@ -14,6 +14,13 @@
 
 #include "grid_map_core/grid_map_core.hpp"
 
+// GCC 13 has false positive warnings around array-bounds.
+// Suppress them until this is fixed in upstream gcc. See
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114758 for more details.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 
 TEST(EigenMatrixBaseAddons, numberOfFinites)
 {

--- a/grid_map_cv/include/grid_map_cv/GridMapCvConverter.hpp
+++ b/grid_map_cv/include/grid_map_cv/GridMapCvConverter.hpp
@@ -20,6 +20,14 @@
 #include <string>
 #include <limits>
 
+// GCC 13 has false positive warnings around stringop-overflow.
+// Suppress them until this is fixed in upstream gcc. See
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114758 for more details.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+
 namespace grid_map
 {
 

--- a/grid_map_filters/CMakeLists.txt
+++ b/grid_map_filters/CMakeLists.txt
@@ -136,6 +136,7 @@ if(BUILD_TESTING)
     list(APPEND AMENT_LINT_AUTO_EXCLUDE
       ament_cmake_cpplint
       ament_cmake_copyright
+      ament_cmake_uncrustify
     )
     ament_lint_auto_find_test_dependencies()
 
@@ -143,6 +144,17 @@ if(BUILD_TESTING)
     find_package(ament_cmake_cpplint)
     ament_cpplint(
       FILTERS -legal/copyright -build/include_order
+    )
+
+    # run uncrustify except for EigenLab.hpp
+    find_package(ament_cmake_uncrustify)
+    set(
+      _linter_excludes
+      include/EigenLab/EigenLab.hpp
+    )
+    ament_uncrustify(
+      EXCLUDE ${_linter_excludes}
+      LANGUAGE c++
     )
   endif()
   ament_lint_auto_find_test_dependencies()

--- a/grid_map_ros/src/GridMapRosConverter.cpp
+++ b/grid_map_ros/src/GridMapRosConverter.cpp
@@ -688,7 +688,7 @@ bool GridMapRosConverter::saveToBag(
 
   auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
 
-  auto ret = rcutils_system_time_now(&bag_message->time_stamp);
+  auto ret = rcutils_system_time_now(&bag_message->send_timestamp);
   if (ret != RCL_RET_OK) {
     RCLCPP_ERROR(rclcpp::get_logger("saveToBag"), "couldn't assign time rosbag message");
   }

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -1,5 +1,6 @@
 repositories:
   ros-planning/navigation2:
     type: git
-    url: https://github.com/wep21/navigation2.git
-    version: rolling
+    # back to upstream main after https://github.com/ros-navigation/navigation2/pull/4298 is merged 
+    url: https://github.com/tonynajjar/navigation2.git
+    version: fix-devcontainer

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -1,5 +1,5 @@
 repositories:
   ros-planning/navigation2:
     type: git
-    url: https://github.com/ros-planning/navigation2.git
-    version: main
+    url: https://github.com/wep21/navigation2.git
+    version: rolling


### PR DESCRIPTION
- skip installing octomap server because it is still not available on rolling.
- ignore compiler warnings due to gcc 13 bug