### PR TITLE
Add bound checks for bilinear interpolation

### DIFF
--- a/grid_map_core/src/GridMap.cpp
+++ b/grid_map_core/src/GridMap.cpp
@@ -782,6 +782,9 @@ bool GridMap::atPositionLinearInterpolated(const std::string& layer, const Posit
 
   getIndex(position, indices[0]);
   getPosition(indices[0], point);
+  if (!checkIfIndexInRange(indices[0], size_)) {
+    return false;
+  }
 
   if (position.x() >= point.x()) {
     indices[1] = indices[0] + Index(-1, 0);  // Second point is above first point.
@@ -789,6 +792,9 @@ bool GridMap::atPositionLinearInterpolated(const std::string& layer, const Posit
   } else {
     indices[1] = indices[0] + Index(+1, 0);
     idxTempDir = false;
+  }
+  if (!checkIfIndexInRange(indices[1], size_)) {
+    return false;
   }
   if (position.y() >= point.y()) {
     indices[2] = indices[0] + Index(0, -1);  // Third point is right of first point.
@@ -818,6 +824,10 @@ bool GridMap::atPositionLinearInterpolated(const std::string& layer, const Posit
       idxShift[3] = 0;
     }
   }
+  if (!checkIfIndexInRange(indices[2], size_)) {
+    return false;
+  }
+
   indices[3].x() = indices[1].x();
   indices[3].y() = indices[2].y();
 


### PR DESCRIPTION
# Issue
Linear interpolation doesn't results in wrong values when queried position is near the map bounds.

I encountered this problem when trying to interpolate a value in a grid map of distance fields, where all values are positive. The result was negative, which didn't align with my expectations. Upon some digging, I noticed that the linear interpolater does not check if the bounds it's trying to compute the position of are out of bounds, which result in strange behaviour.

# Solution
Check that the interpolation points are within the grid map bounds.

# Minimum working example
```cpp
#include <iostream>
#include "grid_map_core/grid_map_core.hpp"

int main() {
  grid_map::GridMap map{};
  map.setGeometry({3, 3}, 1.0);
  const std::string layer = "distance";
  map.add(layer, 0.0);
  // clang-format off
  map[layer] << 
    0.0, 0.0, 0.0,
    0.0, 0.0, 1.0,
    0.0, 1.0, 3.0;
  // clang-format on

  const grid_map::Position pos{-1.49, -1.0};
  if (!map.isInside(pos)) {
    std::cerr << "Position outside map" << std::endl;
    return 1;
  }
  const auto val = map.atPosition(layer, pos, grid_map::InterpolationMethods::INTER_LINEAR);
  std::cout << "Val: " << val << std::endl;
}

```
Outputs before the fix:
```
Val: -1.47
```
which is a negative value even though all values in the map are non-negative.

Output after the fix (it defers to nearet-neighbour):
```
Val: 3
```
