### PR TITLE
initialize marker pose quaternion

### DIFF
--- a/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/MapRegionVisualization.cpp
@@ -49,6 +49,7 @@ bool MapRegionVisualization::initialize()
   marker_.lifetime = ros::Duration();
   marker_.action = visualization_msgs::Marker::ADD;
   marker_.type = visualization_msgs::Marker::LINE_STRIP;
+  marker_.pose.orientation.w = 1.0;
   marker_.scale.x = lineWidth_;
   marker_.points.resize(nVertices_); // Initialized to [0.0, 0.0, 0.0]
   marker_.colors.resize(nVertices_, color_);


### PR DESCRIPTION
This avoids a warning from rviz about uninitialized quaternion- it was automatically setting it to w=1.0 but the warning is annoying.


```
roslaunch grid_map_demos tutorial_demo.launch
```

