### PR TITLE
Fix the Indices of the inpaint filter

### DIFF
--- a/grid_map_cv/include/grid_map_cv/GridMapCvConverter.hpp
+++ b/grid_map_cv/include/grid_map_cv/GridMapCvConverter.hpp
@@ -108,16 +108,17 @@ public:
 
     for (GridMapIterator iterator(gridMap); !iterator.isPastEnd(); ++iterator) {
       const Index index(*iterator);
+      const Index imageIndex(iterator.getUnwrappedIndex());
 
       // Check for alpha layer.
       if (hasAlpha) {
         const Type_ alpha =
-          image.at<cv::Vec<Type_, NChannels_>>(index(0), index(1))[NChannels_ - 1];
+          image.at<cv::Vec<Type_, NChannels_>>(imageIndex(0), imageIndex(1))[NChannels_ - 1];
         if (alpha < alphaTreshold) {continue;}
       }
 
       // Compute value.
-      const Type_ imageValue = imageMono.at<Type_>(index(0), index(1));
+      const Type_ imageValue = imageMono.at<Type_>(imageIndex(0), imageIndex(1));
       const float mapValue = lowerValue + mapValueDifference *
         (static_cast<float>(imageValue) / maxImageValue);
       data(index(0), index(1)) = mapValue;


### PR DESCRIPTION
The inpaint filter does not use the correct indices when creating the new grid map layer.

This issue is also included in the iron release.