### PR TITLE
Use Jazzy image in CI instead of rolling

### DIFF
--- a/.github/workflows/colcon.yaml
+++ b/.github/workflows/colcon.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {rosdistro: 'rolling', container: 'ros:rolling'}
+          - {rosdistro: 'jazzy', container: 'ros:jazzy'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The Jazzy image broke because rolling broke ABI. This should fix it. 

Each time we branch of `rolling`, we need to update the image. `rolling` will only work for a bit. 