### PR TITLE
Check for already declared parameter

### DIFF
--- a/grid_map_cv/include/grid_map_cv/utilities.hpp
+++ b/grid_map_cv/include/grid_map_cv/utilities.hpp
@@ -42,7 +42,10 @@ public:
   {
     rclcpp::Parameter param;
 
-    params_interface_->declare_parameter(param_prefix_ + name, param_type);
+    if (!params_interface_->has_parameter(param_prefix_ + name))
+    {
+      params_interface_->declare_parameter(param_prefix_ + name, param_type);
+    }
     params_interface_->get_parameter(param_prefix_ + name, param);
 
     if (param.get_type() != param_type) {


### PR DESCRIPTION
When using the same parameter for several instances of the filter or a filter chain (like in some ros2 forks of your elevation mapping repository), it will throw rclcpp::exceptions::ParameterAlreadyDeclaredException.
This PR just checks if the parameter already exists before declaring it.