### PR TITLE
fix(SpiralIterator): Avoid improper use of '++', which may cause prog…

### DIFF
--- a/grid_map_core/src/iterators/SpiralIterator.cpp
+++ b/grid_map_core/src/iterators/SpiralIterator.cpp
@@ -49,6 +49,9 @@ const Eigen::Array2i& SpiralIterator::operator *() const
 
 SpiralIterator& SpiralIterator::operator ++()
 {
+  if (isPastEnd()) {
+    return *this;
+  }
   pointsRing_.pop_back();
   if (pointsRing_.empty() && !isPastEnd()) {
     generateRing();


### PR DESCRIPTION
This PR addresses an issue in the SpiralIterator::operator++() function where the pop_back() method was called on an empty pointsRing_ container, leading to undefined behavior. The fix involves adding a check to ensure that pointsRing_ is not empty before attempting to call pop_back(). This change prevents potential crashes and ensures the iterator operates correctly even when the container is empty. 
This change ensures the iterator’s robustness and prevents potential runtime errors.