### PR TITLE
Add test dependency to on rosbag default plugins

### DIFF
--- a/grid_map_ros/package.xml
+++ b/grid_map_ros/package.xml
@@ -32,6 +32,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rosbag2_storage_default_plugins</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
# Purpose

Fix issue in CI with rosbag throwing exception in the CI test environment because it fails to initialize from missing the sqlite plugin

# Tests Performed

None, this is build farm only. in order to reproduce this, I have set up a new CI job in #492. 

I then rebased 492 on top of this PR, and will see if it's resolved.

# Issue

Closes #490 