### PR TITLE
Add industrial CI

### DIFF
--- a/.github/workflows/industrial-ci.yaml
+++ b/.github/workflows/industrial-ci.yaml
@@ -29,5 +29,11 @@ jobs:
       - name: Set UPSTREAM_WORKSPACE to bring in nav2 as a source dependency
         if: ${{ matrix.env.ROS_DISTRO == 'rolling' }}
         run: echo "UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ANYbotics/grid_map/rolling/tools/ros2_dependencies.repos" >> $GITHUB_ENV
+      # We duplicate NAV2's key skipping because I doubt they intend this bespoke file to be used by other CI jobs:
+      # https://github.com/ros-navigation/navigation2/blob/main/tools/skip_keys.txt
+      # It also is out of date, so grid_map is just going to skip keys we are sure don't work.
+      - name: set ROSDEP_SKIP_KEYS to skip nav2 keys
+        if: ${{ matrix.env.ROS_DISTRO == 'rolling' }}
+        run: echo "ROSDEP_SKIP_KEYS=slam_toolbox" >> $GITHUB_ENV
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}

--- a/.github/workflows/industrial-ci.yaml
+++ b/.github/workflows/industrial-ci.yaml
@@ -1,0 +1,29 @@
+name: Industrial CI
+
+# Use industrial CI to ensure our packages express all dependencies.
+# Attempts to find issues like #490 before merge.
+# https://github.com/ros-industrial/industrial_ci?tab=readme-ov-file#for-github-actions
+
+on:
+  push:
+    branches:
+    - 'rolling'
+    - 'jazzy'
+    - 'iron'
+    - 'humble'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: rolling, ROS_REPO: testing}
+          - {ROS_DISTRO: rolling, ROS_REPO: main}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/.github/workflows/industrial-ci.yaml
+++ b/.github/workflows/industrial-ci.yaml
@@ -25,5 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # nav2 on rolling is not available with binaries
+      - name: Set UPSTREAM_WORKSPACE to bring in nav2 as a source dependency
+        if: ${{ matrix.env.ROS_DISTRO == 'rolling' }}
+        run: echo "UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ANYbotics/grid_map/rolling/tools/ros2_dependencies.repos" >> $GITHUB_ENV
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}


### PR DESCRIPTION
# Purpose

Add the ROS industrial CI which supposedly can help find missing dependencies earlier in a more minimal test environment.

# Details

We currently use `rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-desktop-latest` as an image, which contains all dependencies. 

If we forget dependencies in the package.xml, our CI passes, but the jenkins CI fails.

From what I have read, [ros-industrial](https://github.com/ros-industrial/industrial_ci?tab=readme-ov-file#for-github-actions) can solve that.

Let's see if this can reproduce any test failures we have on the jenkins build farm.