### PR TITLE
Fixed missing grid_map_core include dir in installed cmake config

### DIFF
--- a/grid_map_core/CMakeLists.txt
+++ b/grid_map_core/CMakeLists.txt
@@ -125,6 +125,7 @@ if(TARGET ${PROJECT_NAME}-test)
   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 endif()
 
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(Eigen3)
 ament_package(CONFIG_EXTRAS


### PR DESCRIPTION
When including grid_map_core (latest version or jazzy) in a cmake project like this:
```
find_package(grid_map_core)
```
we get error like this:
```
<command-line>: fatal error: grid_map_core/eigen_plugins/FunctorsPlugin.hpp: No such file or directory
compilation terminated.
```
It is because the include directory of that file is not propagated downstream. In Jazzy install directory, we see:
```bash
$ ls /opt/ros/jazzy/share/grid_map_core/cmake
ament_cmake_export_dependencies-extras.cmake  grid_map_core-extras.cmake
ament_cmake_export_targets-extras.cmake       grid_map_coreConfig-version.cmake
export_grid_map_coreExport-none.cmake         grid_map_coreConfig.cmake
export_grid_map_coreExport.cmake
```
And the header file above is added though `ADD_DEFINITIONS` to downstream projects (`grid_map_core-extras.cmake`):
```cmake       
set(EIGEN_FUNCTORS_PLUGIN_PATH "grid_map_core/eigen_plugins/FunctorsPlugin.hpp")
if(EIGEN_FUNCTORS_PLUGIN)
  if(NOT EIGEN_FUNCTORS_PLUGIN STREQUAL EIGEN_FUNCTORS_PLUGIN_PATH)
    message(FATAL_ERROR "EIGEN_FUNCTORS_PLUGIN already defined")
  endif()
else()
  add_definitions(-DEIGEN_FUNCTORS_PLUGIN=\"${EIGEN_FUNCTORS_PLUGIN_PATH}\")
endif()

set(EIGEN_DENSEBASE_PLUGIN_PATH "grid_map_core/eigen_plugins/DenseBasePlugin.hpp")
if(EIGEN_DENSEBASE_PLUGIN)
  if(NOT EIGEN_DENSEBASE_PLUGIN STREQUAL EIGEN_DENSEBASE_PLUGIN_PATH)
    message(FATAL_ERROR "EIGEN_DENSEBASE_PLUGIN already defined!")
  endif()
else()
    add_definitions(-DEIGEN_DENSEBASE_PLUGIN=\"${EIGEN_DENSEBASE_PLUGIN_PATH}\")
```
Comparing to humble release (v2.0.0, which is working), we see there is a missing `ament_cmake_export_include_directories-extras.cmake`. The line in this PR will make that file generated, and the content would look like this:
```cmake
# generated from ament_cmake_export_include_directories/cmake/ament_cmake_export_include_directories-extras.cmake.in

set(_exported_include_dirs "${grid_map_core_DIR}/../../../include/grid_map_core")

# append include directories to grid_map_core_INCLUDE_DIRS
# warn about not existing paths
if(NOT _exported_include_dirs STREQUAL "")
  find_package(ament_cmake_core QUIET REQUIRED)
  foreach(_exported_include_dir ${_exported_include_dirs})
    if(NOT IS_DIRECTORY "${_exported_include_dir}")
      message(WARNING "Package 'grid_map_core' exports the include directory '${_exported_include_dir}' which doesn't exist")
    endif()
    normalize_path(_exported_include_dir "${_exported_include_dir}")
    list(APPEND grid_map_core_INCLUDE_DIRS "${_exported_include_dir}")
  endforeach()
endif()
```

When searching grid_map_core from cmake, it will then state:
```
Found grid_map_core 2.3.0: /opt/ros/jazzy/include/grid_map_core;/usr/include/eigen3
```
instead of just:
```
Found grid_map_core 2.3.0: /usr/include/eigen3
```
