### PR TITLE
Add transitive dependenty for map_msgs

### DIFF
--- a/grid_map_rviz_plugin/package.xml
+++ b/grid_map_rviz_plugin/package.xml
@@ -22,7 +22,9 @@
   <depend>rviz_common</depend>
   <depend>rviz_ogre_vendor</depend>
   <depend>rviz_rendering</depend>
-  
+
+  <build_export_depend>map_msgs</build_export_depend>
+
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-widgets</exec_depend>


### PR DESCRIPTION
Builds for downstream packages fail beacause the `map_msgs` package is exported as a dependency in `CMakeLists.txt`, but is not declared as a dependency in `package.xml`

This is the error we're getting:

```
2025-03-06T06:29:23.7624064Z CMake Error at /opt/ros/humble/share/grid_map_rviz_plugin/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package):
2025-03-06T06:29:23.7625703Z   By not providing "Findmap_msgs.cmake" in CMAKE_MODULE_PATH this project has
2025-03-06T06:29:23.7626810Z   asked CMake to find a package configuration file provided by "map_msgs",
2025-03-06T06:29:23.7627624Z   but CMake did not find one.
2025-03-06T06:29:23.7628000Z 
2025-03-06T06:29:23.7628423Z   Could not find a package configuration file provided by "map_msgs" with any
2025-03-06T06:29:23.7629229Z   of the following names:
2025-03-06T06:29:23.7629566Z
2025-03-06T06:29:23.7629777Z     map_msgsConfig.cmake
2025-03-06T06:29:23.7630272Z     map_msgs-config.cmake
2025-03-06T06:29:23.7630590Z
2025-03-06T06:29:23.7631004Z   Add the installation prefix of "map_msgs" to CMAKE_PREFIX_PATH or set
2025-03-06T06:29:23.7631977Z   "map_msgs_DIR" to a directory containing one of the above files.  If
2025-03-06T06:29:23.7633034Z   "map_msgs" provides a separate development package or SDK, be sure it has
2025-03-06T06:29:23.7633835Z   been installed.
2025-03-06T06:29:23.7634258Z Call Stack (most recent call first):
2025-03-06T06:29:23.7635240Z   /opt/ros/humble/share/grid_map_rviz_plugin/cmake/grid_map_rviz_pluginConfig.cmake:41 (include)
2025-03-06T06:29:23.7636690Z   /opt/ros/humble/share/ament_cmake_auto/cmake/ament_auto_find_build_dependencies.cmake:67 (find_package)
2025-03-06T06:29:23.7638476Z   /opt/ros/humble/share/autoware_cmake/cmake/autoware_package.cmake:49 (ament_auto_find_build_dependencies)
2025-03-06T06:29:23.7639779Z   CMakeLists.txt:5 (autoware_package)
```