### PR TITLE
[ROS2][grid_map_msgs] Added explicit ros1_bridge mapping support

### DIFF
--- a/grid_map_msgs/CMakeLists.txt
+++ b/grid_map_msgs/CMakeLists.txt
@@ -23,6 +23,10 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES std_msgs geometry_msgs
 )
 
+install(
+  FILES ros1_bridge_mapping.yaml
+  DESTINATION share/${PROJECT_NAME})
+  
 ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()

--- a/grid_map_msgs/package.xml
+++ b/grid_map_msgs/package.xml
@@ -24,5 +24,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <ros1_bridge mapping_rules="ros1_bridge_mapping.yaml"/>
   </export>
 </package>

--- a/grid_map_msgs/ros1_bridge_mapping.yaml
+++ b/grid_map_msgs/ros1_bridge_mapping.yaml
@@ -1,0 +1,13 @@
+-
+  ros1_package_name: 'grid_map_msgs'
+  ros1_message_name: 'GridMap'
+  ros2_package_name: 'grid_map_msgs'
+  ros2_message_name: 'GridMap'
+  fields_2_to_1:
+    header: "info.header"
+    info: "info"
+    layers: "layers"
+    basic_layers: "basic_layers"
+    data: "data"
+    outer_start_index: "outer_start_index"
+    inner_start_index: "inner_start_index"


### PR DESCRIPTION
Due to the refactoring of the header member from `GridMapInfo` into `GridMap`, the message structure between ROS1 and ROS2 cannot be bridged correctly. 

This PR added the explicit mapping rule to enable the correct bridging of the GridMap topic 