### PR TITLE
grid_map_sdf: fix planar SDF memory leak

### DIFF
--- a/grid_map_sdf/src/SignedDistanceField.cpp
+++ b/grid_map_sdf/src/SignedDistanceField.cpp
@@ -8,6 +8,8 @@
 
 #include <limits>
 #include <algorithm>
+#include <cmath>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -96,7 +98,8 @@ grid_map::Matrix SignedDistanceField::getPlanarSignedDistanceField(
   Eigen::Dynamic,
   Eigen::Dynamic> & data) const
 {
-  image<uchar> * input = new image<uchar>(data.rows(), data.cols(), true);
+  image<uchar> inputImage(data.rows(), data.cols(), true);
+  auto * input = &inputImage;
 
   for (int y = 0; y < input->height(); y++) {
     for (int x = 0; x < input->width(); x++) {
@@ -105,14 +108,14 @@ grid_map::Matrix SignedDistanceField::getPlanarSignedDistanceField(
   }
 
   // Compute dt.
-  image<float> * out = dt(input);
+  std::unique_ptr<image<float>> out(dt(input));
 
   Matrix result(data.rows(), data.cols());
 
   // Take square roots.
   for (int y = 0; y < out->height(); y++) {
     for (int x = 0; x < out->width(); x++) {
-      result(x, y) = sqrt(imRef(out, x, y));
+      result(x, y) = std::sqrt(imRef(out.get(), x, y));
     }
   }
   return result;


### PR DESCRIPTION
 leak in SignedDistanceField::getPlanarSignedDistanceField(): the temporary distance_transform::image<uchar> and the dt() output were allocated with new and never freed. This switches to RAII (stack allocation + std::unique_ptr) so repeated SDF recomputation doesn't grow memory.