### PR TITLE
Remove deprecated Eigen empty struct constructors

### DIFF
--- a/grid_map_core/include/grid_map_core/eigen_plugins/FunctorsPlugin.hpp
+++ b/grid_map_core/include/grid_map_core/eigen_plugins/FunctorsPlugin.hpp
@@ -6,7 +6,6 @@
 template<typename Scalar>
 struct scalar_sum_of_finites_op
 {
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_sum_of_finites_op)
   EIGEN_STRONG_INLINE const Scalar operator()(const Scalar & a, const Scalar & b) const
   {
     using std::isfinite;
@@ -29,7 +28,6 @@ struct functor_traits<scalar_sum_of_finites_op<Scalar>>
 template<typename Scalar>
 struct scalar_min_of_finites_op
 {
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_min_of_finites_op)
   EIGEN_STRONG_INLINE const Scalar operator()(const Scalar & a, const Scalar & b) const
   {
     using std::min;
@@ -53,7 +51,6 @@ struct functor_traits<scalar_min_of_finites_op<Scalar>>
 template<typename Scalar>
 struct scalar_max_of_finites_op
 {
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_max_of_finites_op)
   EIGEN_STRONG_INLINE const Scalar operator()(const Scalar & a, const Scalar & b) const
   {
     using std::max;


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-grid-map-core.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: Eigen's EIGEN_EMPTY_STRUCT_CTOR macro is no longer needed for these stateless functors and can trigger compatibility issues with newer Eigen/toolchain combinations.
