### PR TITLE
Default copy operations for grid_map_core types

### DIFF
--- a/grid_map_core/include/grid_map_core/BufferRegion.hpp
+++ b/grid_map_core/include/grid_map_core/BufferRegion.hpp
@@ -39,6 +39,8 @@ public:
   BufferRegion(
     const Index & startIndex, const Size & size,
     const BufferRegion::Quadrant & quadrant);
+  BufferRegion(const BufferRegion & other) = default;
+  BufferRegion & operator=(const BufferRegion & other) = default;
   virtual ~BufferRegion() = default;
 
   const Index & getStartIndex() const;

--- a/grid_map_core/include/grid_map_core/Polygon.hpp
+++ b/grid_map_core/include/grid_map_core/Polygon.hpp
@@ -40,6 +40,9 @@ public:
    */
   explicit Polygon(std::vector<Position> vertices);
 
+  Polygon(const Polygon & other) = default;
+  Polygon & operator=(const Polygon & other) = default;
+
   /*!
    * Destructor.
    */


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-grid-map-core.osx.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: explicitly defaulting copy construction and assignment keeps BufferRegion and Polygon usable in containers on toolchains that are stricter around implicit special member generation with aligned Eigen types.
