### PR TITLE
Match grid_map_pcl timer clock type

### DIFF
--- a/grid_map_pcl/include/grid_map_pcl/helpers.hpp
+++ b/grid_map_pcl/include/grid_map_pcl/helpers.hpp
@@ -42,7 +42,7 @@ void saveGridMap(
   const std::string & mapTopic);
 
 inline void printTimeElapsedToRosInfoStream(
-  const std::chrono::system_clock::time_point & start,
+  const std::chrono::high_resolution_clock::time_point & start,
   const std::string & prefix,
   const rclcpp::Logger & node_logger)
 {


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: patch/ros-rolling-grid-map-pcl.osx.patch, authored by Daisuke Nishimatsu.

Best-guess rationale: processPointcloud records the start time with std::chrono::high_resolution_clock::now(), but the helper accepted a system_clock time_point. Matching the helper parameter to the clock used by the caller avoids implementation-dependent clock type mismatches, including libc++ configurations where high_resolution_clock is not system_clock.